### PR TITLE
Add summary and storyline support for games

### DIFF
--- a/app/Console/Commands/ImportGamesFromIGDB.php
+++ b/app/Console/Commands/ImportGamesFromIGDB.php
@@ -17,13 +17,18 @@ class ImportGamesFromIGDB extends Command
         $games = $igdb->fetchGames($this->argument('search'));
 
         foreach ($games as $g) {
+            $summary = $g['summary'] ?? null;
+            $storyline = $g['storyline'] ?? null;
+
             Game::updateOrCreate(
                 ['slug' => Str::slug($g['name'])],
                 [
                     'title' => $g['name'],
                     'twitch_id' => $g['id'],
                     'cover_url' => $g['cover']['url'] ?? null,
-                    'description' => $g['summary'] ?? null,
+                    'summary' => $summary,
+                    'storyline' => $storyline,
+                    'description' => $storyline ?? $summary ?? null,
                 ]
             );
         }

--- a/app/Console/Commands/TranslateGames.php
+++ b/app/Console/Commands/TranslateGames.php
@@ -20,7 +20,9 @@ class TranslateGames extends Command
         if ($this->option('all')) {
             Game::query()
                 ->where(function($q) {
-                    $q->whereNotNull('summary')->orWhereNotNull('storyline');
+                    $q->whereNotNull('summary')
+                        ->orWhereNotNull('storyline')
+                        ->orWhereNotNull('description');
                 })
                 ->pluck('id')
                 ->each(fn ($gid) => TranslateGameTexts::dispatch($gid));

--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -5,14 +5,31 @@ namespace App\Http\Controllers;
 use App\Models\Game;
 use Inertia\Inertia;
 use Inertia\Response;
-use App\Models\GameTranslation;
-
-
 class GameController extends Controller
 {
     public function index(): Response
     {
-        $games = Game::orderByDesc('created_at')->get(['id', 'title', 'slug', 'cover_url', 'description']);
+        $lang = request('lang', 'en');
+
+        $games = Game::orderByDesc('created_at')
+            ->get(['id', 'title', 'slug', 'cover_url', 'summary', 'storyline', 'description'])
+            ->map(function (Game $game) use ($lang) {
+                $texts = $game->localizedTexts($lang);
+                $body = collect([
+                    $texts['storyline'] ?? null,
+                    $texts['summary'] ?? null,
+                ])->filter()->implode("\n\n");
+
+                return [
+                    'id'        => $game->id,
+                    'title'     => $game->title,
+                    'slug'      => $game->slug,
+                    'cover_url' => $game->cover_url,
+                    'summary'   => $texts['summary'],
+                    'storyline' => $texts['storyline'],
+                    'description' => $body !== '' ? $body : null,
+                ];
+            });
 
         return Inertia::render('games/Index', [
             'games' => $games,
@@ -24,12 +41,20 @@ class GameController extends Controller
         $game = Game::where('slug', $slug)->firstOrFail();
         $lang = request('lang', 'en');
 
+        $texts = $game->localizedTexts($lang);
+        $body = collect([
+            $texts['storyline'] ?? null,
+            $texts['summary'] ?? null,
+        ])->filter()->implode("\n\n");
+
         return Inertia::render('games/Show', [
             'game' => [
                 'id'          => $game->id,
                 'title'       => $game->title,
                 'cover_url'   => $game->cover_url,
-                'description' => $game->translatedDescription($lang),
+                'summary'     => $texts['summary'],
+                'storyline'   => $texts['storyline'],
+                'description' => $body !== '' ? $body : null,
                 'comments'    => $game->comments()
                                     ->with('user:id,username')
                                     ->latest()

--- a/app/Services/IGDBService.php
+++ b/app/Services/IGDBService.php
@@ -73,7 +73,7 @@ class IGDBService
             'Authorization' => 'Bearer ' . $token,
         ])->withBody("
             search \"{$search}\";
-            fields name,slug,cover.url,summary;
+            fields name,slug,cover.url,summary,storyline;
             limit 5;
         ", 'text/plain')->post('https://api.igdb.com/v4/games');
 

--- a/database/migrations/2025_09_26_000000_add_summary_and_storyline_to_games_table.php
+++ b/database/migrations/2025_09_26_000000_add_summary_and_storyline_to_games_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->longText('summary')->nullable()->after('description');
+            $table->longText('storyline')->nullable()->after('summary');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->dropColumn(['summary', 'storyline']);
+        });
+    }
+};

--- a/database/seeders/DummyGameSeeder.php
+++ b/database/seeders/DummyGameSeeder.php
@@ -16,7 +16,9 @@ class DummyGameSeeder extends Seeder
             [
                 'title'       => 'Starfield',
                 'cover_url'   => 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2x9k.jpg',
-                'description' => "Starfield is a next-generation role-playing game set among the stars. Create any character you want and explore with unparalleled freedom as you embark on an epic journey to answer humanity’s greatest mystery."
+                'storyline'   => 'In the year 2330 humanity ventures beyond the solar system as part of the spacefaring organization Constellation.',
+                'summary'     => 'Starfield is a next-generation role-playing game set among the stars. Create any character you want and explore with unparalleled freedom as you embark on an epic journey to answer humanity’s greatest mystery.',
+                'description' => 'In the year 2330 humanity ventures beyond the solar system as part of the spacefaring organization Constellation.'
             ]
         );
 
@@ -25,7 +27,9 @@ class DummyGameSeeder extends Seeder
             [
                 'title'       => 'ELDEN RING',
                 'cover_url'   => 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1x3h.jpg',
-                'description' => "Rise, Tarnished, and be guided by grace to brandish the power of the Elden Ring and become an Elden Lord in the Lands Between."
+                'storyline'   => 'Guided by the Greater Will, the Tarnished traverse the Lands Between to seek the shattered fragments of the Elden Ring.',
+                'summary'     => 'Rise, Tarnished, and be guided by grace to brandish the power of the Elden Ring and become an Elden Lord in the Lands Between.',
+                'description' => 'Guided by the Greater Will, the Tarnished traverse the Lands Between to seek the shattered fragments of the Elden Ring.'
             ]
         );
     }

--- a/resources/js/pages/games/Index.vue
+++ b/resources/js/pages/games/Index.vue
@@ -10,6 +10,8 @@ defineProps<{
         title: string;
         slug: string;
         cover_url: string | null;
+        summary: string | null;
+        storyline: string | null;
         description: string | null;
     }[];
 }>();
@@ -33,7 +35,9 @@ defineProps<{
                     {{ game.title }}
                 </inertia-link>
 
-                <p class="text-sm text-gray-600" v-if="game.description">{{ game.description }}</p>
+                <p class="text-sm text-gray-600" v-if="game.storyline || game.summary || game.description">
+                    {{ game.storyline ?? game.summary ?? game.description }}
+                </p>
             </div>
         </div>
     </div>

--- a/resources/js/pages/games/Show.vue
+++ b/resources/js/pages/games/Show.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useForm, usePage, Head, router } from '@inertiajs/vue3';
+import { computed } from 'vue';
 
 // Props du jeu et des flash messages
 const props = defineProps<{
@@ -7,6 +8,8 @@ const props = defineProps<{
         id: number;
         title: string;
         cover_url: string | null;
+        summary: string | null;
+        storyline: string | null;
         description: string | null;
         comments: {
             id: number;
@@ -44,6 +47,18 @@ const deleteComment = (id: number) => {
         });
     }
 };
+
+const displayText = computed(() => {
+    const parts = [props.game.storyline, props.game.summary, props.game.description].filter(
+        (value): value is string => Boolean(value && value.trim())
+    );
+
+    if (!parts.length) {
+        return null;
+    }
+
+    return parts.join('\n\n');
+});
 </script>
 
 <template>
@@ -70,8 +85,8 @@ const deleteComment = (id: number) => {
         />
 
         <!-- Description -->
-        <p class="text-lg text-gray-700 mb-10">
-            {{ game.description ?? 'Aucune description disponible.' }}
+        <p class="text-lg text-gray-700 mb-10 whitespace-pre-line">
+            {{ displayText ?? 'Aucune description disponible.' }}
         </p>
 
         <!-- Zone de commentaires -->


### PR DESCRIPTION
## Summary
- add a migration introducing nullable `summary` and `storyline` columns on games
- populate the new fields throughout imports, seeders, models, controllers, and UI so they surface in the app
- update the translation job/command to translate the new fields with graceful fallbacks

## Testing
- `php artisan migrate` *(fails: vendor/autoload.php missing because Composer cannot reach GitHub from the container)*
- `php artisan games:translate --all` *(fails: vendor/autoload.php missing because Composer cannot reach GitHub from the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6561e7384832ca5dbd26f9cd98e88