### PR TITLE
Trigger translations during IGDB import

### DIFF
--- a/tests/Feature/Console/ImportGamesFromIGDBTest.php
+++ b/tests/Feature/Console/ImportGamesFromIGDBTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\Game;
+use App\Models\GameTranslation;
+use App\Services\IGDBService;
+use App\Services\Translator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+
+uses(RefreshDatabase::class);
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('imports games and triggers translations when text is provided', function () {
+    $mock = Mockery::mock(IGDBService::class);
+    $mock->shouldReceive('fetchGames')
+        ->once()
+        ->with('zelda')
+        ->andReturn([
+            [
+                'id' => 123,
+                'name' => 'The Legend of Testing',
+                'summary' => 'An epic summary waiting for translation.',
+            ],
+        ]);
+
+    $this->app->instance(IGDBService::class, $mock);
+
+    $this->app->bind(Translator::class, fn () => new class implements Translator {
+        public function translate(string $text, string $to = 'fr', ?string $from = 'en'): string
+        {
+            return "[{$to}] {$text}";
+        }
+    });
+
+    $this->artisan('games:import', ['search' => 'zelda'])
+        ->expectsOutput('Games imported successfully (translations dispatched).')
+        ->assertExitCode(0);
+
+    $game = Game::where('slug', 'the-legend-of-testing')->first();
+    expect($game)->not->toBeNull();
+
+    $translation = GameTranslation::where('game_id', $game->id)->first();
+    expect($translation)->not->toBeNull()
+        ->and($translation->summary)->toBe('[fr] An epic summary waiting for translation.');
+});


### PR DESCRIPTION
## Summary
- dispatch synchronous translations for imported games when textual fields are present
- update the console output to indicate translations are triggered during import
- cover the import workflow with a feature test that asserts translations are stored automatically

## Testing
- ⚠️ `php artisan test --filter=ImportGamesFromIGDBTest` *(blocked: composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6628632a4832c9bfc6951eb50437f