### PR TITLE
Expose dashboard publicly and add informational pages

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -1,25 +1,10 @@
 <script setup lang="ts">
 import AppLogo from '@/components/AppLogo.vue';
-import AppLogoIcon from '@/components/AppLogoIcon.vue';
 import Breadcrumbs from '@/components/Breadcrumbs.vue';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import {
-    NavigationMenu,
-    NavigationMenuItem,
-    NavigationMenuLink,
-    NavigationMenuList,
-    navigationMenuTriggerStyle,
-} from '@/components/ui/navigation-menu';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import UserMenuContent from '@/components/UserMenuContent.vue';
-import { getInitials } from '@/composables/useInitials';
-import type { BreadcrumbItem, NavItem } from '@/types';
+import type { BreadcrumbItem, NavItem, SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-vue-next';
-import { computed } from 'vue';
+import { Menu, X } from 'lucide-vue-next';
+import { computed, ref } from 'vue';
 
 interface Props {
     breadcrumbs?: BreadcrumbItem[];
@@ -29,162 +14,130 @@ const props = withDefaults(defineProps<Props>(), {
     breadcrumbs: () => [],
 });
 
-const page = usePage();
-const auth = computed(() => page.props.auth);
-
-const isCurrentRoute = computed(() => (url: string) => page.url === url);
-
-const activeItemStyles = computed(
-    () => (url: string) => (isCurrentRoute.value(url) ? 'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100' : ''),
-);
+const page = usePage<SharedData>();
+const user = computed(() => page.props.auth.user);
 
 const mainNavItems: NavItem[] = [
     {
-        title: 'Dashboard',
-        href: '/dashboard',
-        icon: LayoutGrid,
+        title: 'Accueil',
+        href: '/',
+    },
+    {
+        title: 'Jeux',
+        href: '/games',
+    },
+    {
+        title: 'Information',
+        href: '/information',
+    },
+    {
+        title: 'Présentation',
+        href: '/presentation',
     },
 ];
 
-const rightNavItems: NavItem[] = [
-    {
-        title: 'Repository',
-        href: 'https://github.com/laravel/vue-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits',
-        icon: BookOpen,
-    },
-];
+const isCurrentRoute = (href: string) => page.url === href;
+
+const mobileMenuOpen = ref(false);
+
+const toggleMobileMenu = () => {
+    mobileMenuOpen.value = !mobileMenuOpen.value;
+};
+
+const closeMobileMenu = () => {
+    mobileMenuOpen.value = false;
+};
 </script>
 
 <template>
-    <div>
-        <div class="border-b border-sidebar-border/80">
-            <div class="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
-                <!-- Mobile Menu -->
-                <div class="lg:hidden">
-                    <Sheet>
-                        <SheetTrigger :as-child="true">
-                            <Button variant="ghost" size="icon" class="mr-2 h-9 w-9">
-                                <Menu class="h-5 w-5" />
-                            </Button>
-                        </SheetTrigger>
-                        <SheetContent side="left" class="w-[300px] p-6">
-                            <SheetTitle class="sr-only">Navigation Menu</SheetTitle>
-                            <SheetHeader class="flex justify-start text-left">
-                                <AppLogoIcon class="size-6 fill-current text-black dark:text-white" />
-                            </SheetHeader>
-                            <div class="flex h-full flex-1 flex-col justify-between space-y-4 py-6">
-                                <nav class="-mx-3 space-y-1">
-                                    <Link
-                                        v-for="item in mainNavItems"
-                                        :key="item.title"
-                                        :href="item.href"
-                                        class="flex items-center gap-x-3 rounded-lg px-3 py-2 text-sm font-medium hover:bg-accent"
-                                        :class="activeItemStyles(item.href)"
-                                    >
-                                        <component v-if="item.icon" :is="item.icon" class="h-5 w-5" />
-                                        {{ item.title }}
-                                    </Link>
-                                </nav>
-                                <div class="flex flex-col space-y-4">
-                                    <a
-                                        v-for="item in rightNavItems"
-                                        :key="item.title"
-                                        :href="item.href"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        class="flex items-center space-x-2 text-sm font-medium"
-                                    >
-                                        <component v-if="item.icon" :is="item.icon" class="h-5 w-5" />
-                                        <span>{{ item.title }}</span>
-                                    </a>
-                                </div>
-                            </div>
-                        </SheetContent>
-                    </Sheet>
-                </div>
-
-                <Link :href="route('dashboard')" class="flex items-center gap-x-2">
+    <div class="border-b border-sidebar-border/80 bg-white/80 backdrop-blur dark:bg-neutral-950/70">
+        <div class="mx-auto flex h-16 items-center justify-between px-4 md:max-w-7xl">
+            <div class="flex items-center gap-2">
+                <button
+                    type="button"
+                    class="inline-flex items-center justify-center rounded-md p-2 text-neutral-700 transition hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary lg:hidden dark:text-neutral-200 dark:hover:bg-neutral-800"
+                    :aria-expanded="mobileMenuOpen"
+                    aria-controls="primary-navigation"
+                    @click="toggleMobileMenu"
+                >
+                    <span class="sr-only">Basculer la navigation</span>
+                    <Menu v-if="!mobileMenuOpen" class="h-6 w-6" />
+                    <X v-else class="h-6 w-6" />
+                </button>
+                <Link :href="route('home')" class="flex items-center gap-2" @click="closeMobileMenu">
                     <AppLogo />
                 </Link>
+            </div>
 
-                <!-- Desktop Menu -->
-                <div class="hidden h-full lg:flex lg:flex-1">
-                    <NavigationMenu class="ml-10 flex h-full items-stretch">
-                        <NavigationMenuList class="flex h-full items-stretch space-x-2">
-                            <NavigationMenuItem v-for="(item, index) in mainNavItems" :key="index" class="relative flex h-full items-center">
-                                <Link :href="item.href">
-                                    <NavigationMenuLink
-                                        :class="[navigationMenuTriggerStyle(), activeItemStyles(item.href), 'h-9 cursor-pointer px-3']"
-                                    >
-                                        <component v-if="item.icon" :is="item.icon" class="mr-2 h-4 w-4" />
-                                        {{ item.title }}
-                                    </NavigationMenuLink>
-                                </Link>
-                                <div
-                                    v-if="isCurrentRoute(item.href)"
-                                    class="absolute bottom-0 left-0 h-0.5 w-full translate-y-px bg-black dark:bg-white"
-                                ></div>
-                            </NavigationMenuItem>
-                        </NavigationMenuList>
-                    </NavigationMenu>
-                </div>
+            <nav class="hidden items-center gap-6 text-sm font-medium lg:flex" aria-label="Navigation principale">
+                <Link
+                    v-for="item in mainNavItems"
+                    :key="item.title"
+                    :href="item.href"
+                    class="transition hover:text-primary"
+                    :class="isCurrentRoute(item.href) ? 'text-primary' : 'text-neutral-600 dark:text-neutral-300'"
+                >
+                    {{ item.title }}
+                </Link>
+                <Link
+                    v-if="!user"
+                    :href="route('login')"
+                    class="rounded-lg bg-primary px-4 py-2 font-semibold text-white shadow hover:bg-primary/90"
+                >
+                    Connexion
+                </Link>
+                <Link
+                    v-else
+                    method="post"
+                    as="button"
+                    type="button"
+                    :href="route('logout')"
+                    class="rounded-lg bg-red-500 px-4 py-2 font-semibold text-white shadow hover:bg-red-500/90"
+                >
+                    Déconnexion
+                </Link>
+            </nav>
+        </div>
 
-                <div class="ml-auto flex items-center space-x-2">
-                    <div class="relative flex items-center space-x-1">
-                        <Button variant="ghost" size="icon" class="group h-9 w-9 cursor-pointer">
-                            <Search class="size-5 opacity-80 group-hover:opacity-100" />
-                        </Button>
-
-                        <div class="hidden space-x-1 lg:flex">
-                            <template v-for="item in rightNavItems" :key="item.title">
-                                <TooltipProvider :delay-duration="0">
-                                    <Tooltip>
-                                        <TooltipTrigger>
-                                            <Button variant="ghost" size="icon" as-child class="group h-9 w-9 cursor-pointer">
-                                                <a :href="item.href" target="_blank" rel="noopener noreferrer">
-                                                    <span class="sr-only">{{ item.title }}</span>
-                                                    <component :is="item.icon" class="size-5 opacity-80 group-hover:opacity-100" />
-                                                </a>
-                                            </Button>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                            <p>{{ item.title }}</p>
-                                        </TooltipContent>
-                                    </Tooltip>
-                                </TooltipProvider>
-                            </template>
-                        </div>
-                    </div>
-
-                    <DropdownMenu>
-                        <DropdownMenuTrigger :as-child="true">
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                class="relative size-10 w-auto rounded-full p-1 focus-within:ring-2 focus-within:ring-primary"
-                            >
-                                <Avatar class="size-8 overflow-hidden rounded-full">
-                                    <AvatarImage v-if="auth.user.avatar" :src="auth.user.avatar" :alt="auth.user.name" />
-                                    <AvatarFallback class="rounded-lg bg-neutral-200 font-semibold text-black dark:bg-neutral-700 dark:text-white">
-                                        {{ getInitials(auth.user?.name) }}
-                                    </AvatarFallback>
-                                </Avatar>
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" class="w-56">
-                            <UserMenuContent :user="auth.user" />
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                </div>
+        <div
+            v-if="mobileMenuOpen"
+            id="primary-navigation"
+            class="border-t border-sidebar-border/80 bg-white/95 px-4 py-4 shadow-lg lg:hidden dark:bg-neutral-950/95"
+        >
+            <div class="flex flex-col gap-3 text-base font-medium">
+                <Link
+                    v-for="item in mainNavItems"
+                    :key="item.title"
+                    :href="item.href"
+                    class="rounded-lg px-3 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                    :class="isCurrentRoute(item.href) ? 'bg-neutral-100 font-semibold dark:bg-neutral-800' : 'text-neutral-700 dark:text-neutral-200'"
+                    @click="closeMobileMenu"
+                >
+                    {{ item.title }}
+                </Link>
+                <Link
+                    v-if="!user"
+                    :href="route('login')"
+                    class="rounded-lg bg-primary px-3 py-2 text-center font-semibold text-white hover:bg-primary/90"
+                    @click="closeMobileMenu"
+                >
+                    Connexion
+                </Link>
+                <Link
+                    v-else
+                    method="post"
+                    as="button"
+                    type="button"
+                    :href="route('logout')"
+                    class="rounded-lg bg-red-500 px-3 py-2 text-center font-semibold text-white hover:bg-red-500/90"
+                    @click="closeMobileMenu"
+                >
+                    Déconnexion
+                </Link>
             </div>
         </div>
 
-        <div v-if="props.breadcrumbs.length > 1" class="flex w-full border-b border-sidebar-border/70">
+        <div v-if="props.breadcrumbs.length > 1" class="flex w-full border-t border-sidebar-border/70 bg-white/60 dark:bg-neutral-950/60">
             <div class="mx-auto flex h-12 w-full items-center justify-start px-4 text-neutral-500 md:max-w-7xl">
                 <Breadcrumbs :breadcrumbs="breadcrumbs" />
             </div>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import AppLayout from '@/layouts/AppLayout.vue';
+import AppHeaderLayout from '@/layouts/app/AppHeaderLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
 import PlaceholderPattern from '../components/PlaceholderPattern.vue';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
-        title: 'Dashboard',
-        href: '/dashboard',
+        title: 'Accueil',
+        href: '/',
     },
 ];
 </script>
@@ -15,7 +15,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 <template>
     <Head title="Dashboard" />
 
-    <AppLayout :breadcrumbs="breadcrumbs">
+    <AppHeaderLayout :breadcrumbs="breadcrumbs">
         <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
             <div class="grid auto-rows-min gap-4 md:grid-cols-3">
                 <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
@@ -32,5 +32,5 @@ const breadcrumbs: BreadcrumbItem[] = [
                 <PlaceholderPattern />
             </div>
         </div>
-    </AppLayout>
+    </AppHeaderLayout>
 </template>

--- a/resources/js/pages/Information.vue
+++ b/resources/js/pages/Information.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import AppHeaderLayout from '@/layouts/app/AppHeaderLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Head } from '@inertiajs/vue3';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Accueil',
+        href: '/',
+    },
+    {
+        title: 'Information',
+        href: '/information',
+    },
+];
+</script>
+
+<template>
+    <Head title="Information" />
+
+    <AppHeaderLayout :breadcrumbs="breadcrumbs">
+        <div class="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-10">
+            <h1 class="text-3xl font-bold text-neutral-900 dark:text-neutral-100">Information</h1>
+            <p class="text-base leading-relaxed text-neutral-600 dark:text-neutral-300">
+                Bienvenue sur LevelUp. Vous trouverez ici toutes les informations essentielles sur notre plateforme et sur les services que nous proposons aux passionnés de jeux vidéo. Explorez les différentes sections pour découvrir comment profiter pleinement de l'expérience LevelUp.
+            </p>
+            <section class="space-y-4 rounded-xl border border-sidebar-border/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-sidebar-border dark:bg-neutral-900/80">
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">Nos engagements</h2>
+                <ul class="list-disc space-y-2 pl-5 text-neutral-600 dark:text-neutral-300">
+                    <li>Mettre en avant les meilleurs jeux du moment avec des fiches détaillées.</li>
+                    <li>Proposer des analyses et des recommandations pour guider vos choix.</li>
+                    <li>Offrir une communauté accueillante et active autour du jeu vidéo.</li>
+                </ul>
+            </section>
+            <section class="space-y-4 rounded-xl border border-sidebar-border/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-sidebar-border dark:bg-neutral-900/80">
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">Besoin d'aide ?</h2>
+                <p class="text-neutral-600 dark:text-neutral-300">
+                    Notre équipe reste disponible pour répondre à vos questions. Contactez-nous via les canaux habituels ou rendez-vous sur votre espace personnel pour accéder au support si vous disposez déjà d'un compte.
+                </p>
+            </section>
+        </div>
+    </AppHeaderLayout>
+</template>

--- a/resources/js/pages/Presentation.vue
+++ b/resources/js/pages/Presentation.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import AppHeaderLayout from '@/layouts/app/AppHeaderLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Head } from '@inertiajs/vue3';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Accueil',
+        href: '/',
+    },
+    {
+        title: 'Présentation',
+        href: '/presentation',
+    },
+];
+</script>
+
+<template>
+    <Head title="Présentation" />
+
+    <AppHeaderLayout :breadcrumbs="breadcrumbs">
+        <div class="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-10">
+            <h1 class="text-3xl font-bold text-neutral-900 dark:text-neutral-100">Présentation</h1>
+            <p class="text-base leading-relaxed text-neutral-600 dark:text-neutral-300">
+                LevelUp est une plateforme dédiée aux joueurs qui souhaitent découvrir de nouveaux titres, suivre l'actualité vidéoludique et partager leur passion. Notre mission est de créer un espace moderne et intuitif pour explorer les jeux qui comptent pour vous.
+            </p>
+            <section class="space-y-4 rounded-xl border border-sidebar-border/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-sidebar-border dark:bg-neutral-900/80">
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">Ce que nous proposons</h2>
+                <ul class="list-disc space-y-2 pl-5 text-neutral-600 dark:text-neutral-300">
+                    <li>Un tableau de bord pour suivre les nouveautés et vos jeux favoris.</li>
+                    <li>Des fiches détaillées avec captures, résumés et impressions.</li>
+                    <li>Une interface soignée accessible sur ordinateur comme sur mobile.</li>
+                </ul>
+            </section>
+            <section class="space-y-4 rounded-xl border border-sidebar-border/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-sidebar-border dark:bg-neutral-900/80">
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">Rejoignez la communauté</h2>
+                <p class="text-neutral-600 dark:text-neutral-300">
+                    Créez un compte pour accéder à toutes les fonctionnalités : consulter le catalogue de jeux, laisser des avis et personnaliser votre expérience. Nous avons hâte de vous retrouver en jeu !
+                </p>
+            </section>
+        </div>
+    </AppHeaderLayout>
+</template>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -3,7 +3,7 @@ import type { LucideIcon } from 'lucide-vue-next';
 import type { Config } from 'ziggy-js';
 
 export interface Auth {
-    user: User;
+    user: User | null;
 }
 
 export interface BreadcrumbItem {


### PR DESCRIPTION
## Summary
- make the dashboard the public landing page and require authentication for game listings
- refresh the header navigation to expose home, games, information, presentation, login, and logout links
- add dedicated Information and Présentation content pages linked from the navbar

## Testing
- npm run build *(fails: missing vendor/tightenco/ziggy dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66cf584cc832ca7dd2f01a1db227e