### PR TITLE
Add admin comment moderation dashboard

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -5,9 +5,54 @@ namespace App\Http\Controllers;
 use App\Models\Comment;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
 
 class CommentController extends Controller
 {
+    public function index(Request $request): Response
+    {
+        $comments = Comment::query()
+            ->with(['user:id,username', 'game:id,title,slug'])
+            ->latest()
+            ->paginate(15)
+            ->through(fn (Comment $comment) => [
+                'id' => $comment->id,
+                'content' => $comment->content,
+                'created_at' => $comment->created_at->toIso8601String(),
+                'user' => [
+                    'id' => $comment->user->id,
+                    'username' => $comment->user->username,
+                ],
+                'game' => [
+                    'id' => $comment->game->id,
+                    'title' => $comment->game->title,
+                    'slug' => $comment->game->slug,
+                ],
+            ]);
+
+        return Inertia::render('admin/Comments', [
+            'comments' => [
+                'data' => $comments->items(),
+                'links' => $comments->linkCollection()->map(fn ($link) => [
+                    'url' => $link['url'],
+                    'label' => $link['label'],
+                    'active' => $link['active'],
+                ])->values(),
+                'meta' => [
+                    'current_page' => $comments->currentPage(),
+                    'last_page' => $comments->lastPage(),
+                    'per_page' => $comments->perPage(),
+                    'total' => $comments->total(),
+                ],
+            ],
+            'flash' => [
+                'success' => $request->session()->get('success'),
+                'error' => $request->session()->get('error'),
+            ],
+        ]);
+    }
+
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -24,9 +69,11 @@ class CommentController extends Controller
         return back()->with('success', 'Commentaire ajouté.');
     }
 
-    public function destroy(Comment $comment)
+    public function destroy(Request $request, Comment $comment)
     {
-        if ($comment->user_id !== auth()->id()) {
+        $user = $request->user();
+
+        if (! $user || ($comment->user_id !== $user->id && ! $user->is_admin)) {
             abort(403);
         }
 

--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->is_admin) {
+            abort(403, 'Cette section est réservée aux administrateurs.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,6 +35,7 @@ class User extends Authenticatable
         'country',
         'age',
         'password',
+        'is_admin',
     ];
 
     /**
@@ -57,6 +58,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureUserIsAdmin;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
@@ -24,6 +25,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'subscribed' => \App\Http\Middleware\EnsureUserIsSubscribed::class,
+            'admin' => EnsureUserIsAdmin::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -25,10 +25,18 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
+            'username' => fake()->unique()->userName(),
             'email' => fake()->unique()->safeEmail(),
+            'phone' => fake()->phoneNumber(),
+            'address' => fake()->streetAddress(),
+            'city' => fake()->city(),
+            'cp' => fake()->postcode(),
+            'country' => fake()->country(),
+            'age' => fake()->numberBetween(18, 80),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'is_admin' => false,
         ];
     }
 

--- a/database/migrations/2025_10_04_000000_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_10_04_000000_add_is_admin_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -3,18 +3,33 @@ import NavFooter from '@/components/NavFooter.vue';
 import NavMain from '@/components/NavMain.vue';
 import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
-import { type NavItem } from '@/types';
-import { Link } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-vue-next';
+import { type NavItem, type SharedData } from '@/types';
+import { Link, usePage } from '@inertiajs/vue3';
+import { BookOpen, Folder, LayoutGrid, MessageSquare } from 'lucide-vue-next';
+import { computed } from 'vue';
 import AppLogo from './AppLogo.vue';
 
-const mainNavItems: NavItem[] = [
-    {
-        title: 'Dashboard',
-        href: '/dashboard',
-        icon: LayoutGrid,
-    },
-];
+const page = usePage<SharedData>();
+
+const mainNavItems = computed<NavItem[]>(() => {
+    const items: NavItem[] = [
+        {
+            title: 'Dashboard',
+            href: route('dashboard'),
+            icon: LayoutGrid,
+        },
+    ];
+
+    if (page.props.auth.user?.is_admin) {
+        items.push({
+            title: 'Commentaires',
+            href: route('admin.comments.index'),
+            icon: MessageSquare,
+        });
+    }
+
+    return items;
+});
 
 const footerNavItems: NavItem[] = [
     {

--- a/resources/js/pages/admin/Comments.vue
+++ b/resources/js/pages/admin/Comments.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import type { BreadcrumbItem } from '@/types';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+defineProps<{
+    comments: {
+        data: Array<{
+            id: number;
+            content: string;
+            created_at: string;
+            user: { id: number; username: string };
+            game: { id: number; title: string; slug: string };
+        }>;
+        links: Array<{
+            url: string | null;
+            label: string;
+            active: boolean;
+        }>;
+        meta: {
+            current_page: number;
+            last_page: number;
+            per_page: number;
+            total: number;
+        };
+    };
+    flash?: {
+        success?: string | null;
+        error?: string | null;
+    };
+}>();
+
+const breadcrumbs = computed<BreadcrumbItem[]>(() => [
+    {
+        title: 'Dashboard',
+        href: route('dashboard'),
+    },
+    {
+        title: 'Modération des commentaires',
+        href: route('admin.comments.index'),
+    },
+]);
+
+const formatDate = (value: string) =>
+    new Intl.DateTimeFormat('fr-FR', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(value));
+
+const deleteComment = (id: number) => {
+    if (confirm('Supprimer ce commentaire ?')) {
+        router.delete(route('comments.destroy', id), {
+            preserveScroll: true,
+        });
+    }
+};
+</script>
+
+<template>
+    <Head title="Modération des commentaires" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="space-y-6 p-6">
+            <div v-if="flash?.success" class="rounded-lg border border-green-300 bg-green-100 px-4 py-3 text-sm text-green-700">
+                {{ flash.success }}
+            </div>
+            <div v-if="flash?.error" class="rounded-lg border border-red-300 bg-red-100 px-4 py-3 text-sm text-red-700">
+                {{ flash.error }}
+            </div>
+
+            <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+                <div class="border-b border-gray-200 bg-gray-50 px-6 py-4 dark:border-neutral-800 dark:bg-neutral-950">
+                    <h1 class="text-lg font-semibold">Tous les commentaires ({{ comments.meta.total }})</h1>
+                    <p class="text-sm text-gray-600 dark:text-neutral-400">
+                        Consultez et modérez les derniers avis laissés sur les jeux de la plateforme.
+                    </p>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200 text-left text-sm dark:divide-neutral-800">
+                        <thead class="bg-gray-50 text-xs font-medium uppercase tracking-wide text-gray-500 dark:bg-neutral-950 dark:text-neutral-400">
+                            <tr>
+                                <th scope="col" class="px-6 py-3">Jeu</th>
+                                <th scope="col" class="px-6 py-3">Auteur</th>
+                                <th scope="col" class="px-6 py-3">Commentaire</th>
+                                <th scope="col" class="px-6 py-3">Publié le</th>
+                                <th scope="col" class="px-6 py-3 text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-neutral-800">
+                            <tr v-for="comment in comments.data" :key="comment.id" class="bg-white dark:bg-neutral-900">
+                                <td class="px-6 py-4">
+                                    <Link :href="route('games.show', { slug: comment.game.slug })" class="font-medium text-blue-600 hover:underline">
+                                        {{ comment.game.title }}
+                                    </Link>
+                                </td>
+                                <td class="px-6 py-4 font-medium text-gray-700 dark:text-neutral-200">
+                                    @{{ comment.user.username }}
+                                </td>
+                                <td class="px-6 py-4 text-gray-600 dark:text-neutral-300">
+                                    {{ comment.content }}
+                                </td>
+                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-neutral-400">
+                                    {{ formatDate(comment.created_at) }}
+                                </td>
+                                <td class="px-6 py-4 text-right">
+                                    <button
+                                        type="button"
+                                        class="rounded border border-red-200 px-3 py-1 text-sm font-medium text-red-600 transition hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                                        @click="deleteComment(comment.id)"
+                                    >
+                                        Supprimer
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr v-if="comments.data.length === 0">
+                                <td colspan="5" class="px-6 py-10 text-center text-sm text-gray-500 dark:text-neutral-400">
+                                    Aucun commentaire n'a encore été publié sur la plateforme.
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <nav v-if="comments.meta.last_page > 1" class="flex justify-center">
+                <ul class="flex items-center gap-2">
+                    <li v-for="link in comments.links" :key="link.label">
+                        <Link
+                            v-if="link.url"
+                            :href="link.url"
+                            preserve-state
+                            preserve-scroll
+                            class="inline-flex items-center rounded-md border px-3 py-1 text-sm font-medium transition"
+                            :class="[
+                                link.active
+                                    ? 'border-primary bg-primary text-white'
+                                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800',
+                            ]"
+                            v-html="link.label"
+                        />
+                        <span
+                            v-else
+                            class="inline-flex items-center rounded-md border border-gray-200 px-3 py-1 text-sm font-medium text-gray-400 dark:border-neutral-800 dark:text-neutral-600"
+                            v-html="link.label"
+                        />
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/pages/games/Show.vue
+++ b/resources/js/pages/games/Show.vue
@@ -143,7 +143,10 @@ const displayText = computed(() => {
                         <div class="flex items-center justify-between">
                             <p class="font-semibold text-blue-700">@{{ comment.user.username }}</p>
                             <button
-                                v-if="auth.user && auth.user.username === comment.user.username"
+                                v-if="
+                                    auth.user &&
+                                    (auth.user.username === comment.user.username || auth.user.is_admin)
+                                "
                                 @click="deleteComment(comment.id)"
                                 class="text-sm text-red-500 hover:underline"
                             >

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -30,10 +30,12 @@ export interface User {
     id: number;
     name: string;
     email: string;
+    username: string;
     avatar?: string;
     email_verified_at: string | null;
     created_at: string;
     updated_at: string;
+    is_admin: boolean;
 }
 
 export type BreadcrumbItemType = BreadcrumbItem;

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,10 @@ Route::middleware('auth')->group(function () {
 });
 Route::middleware('auth')->delete('/comments/{comment}', [CommentController::class, 'destroy'])->name('comments.destroy');
 
+Route::middleware(['auth', 'admin'])->group(function () {
+    Route::get('/admin/comments', [CommentController::class, 'index'])->name('admin.comments.index');
+});
+
 use App\Http\Controllers\Auth\SocialiteController;
 
 Route::get('/auth/{provider}/redirect', [SocialiteController::class, 'redirect'])


### PR DESCRIPTION
## Summary
- add an admin-only comments moderation route, controller action, and Vue page with pagination
- gate access behind a new admin middleware and expose admin state to the UI navigation
- extend user schema with an is_admin flag and seed data to support factories while allowing admins to delete any comment

## Testing
- php artisan test *(fails: vendor directory is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a77ed6c8832ca6b394e01570c96b