### PR TITLE
Add admin menu and powers management

### DIFF
--- a/app/Http/Controllers/Admin/PowersController.php
+++ b/app/Http/Controllers/Admin/PowersController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PowersController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $users = User::query()
+            ->select(['id', 'name', 'username', 'email', 'is_admin', 'created_at'])
+            ->orderBy('name')
+            ->orderBy('username')
+            ->get()
+            ->map(fn (User $user) => [
+                'id'        => $user->id,
+                'name'      => $user->name,
+                'username'  => $user->username,
+                'email'     => $user->email,
+                'is_admin'  => $user->is_admin,
+                'joined_at' => $user->created_at?->toIso8601String(),
+            ]);
+
+        return Inertia::render('admin/Powers', [
+            'users' => $users,
+            'flash' => [
+                'success' => $request->session()->get('success'),
+                'error'   => $request->session()->get('error'),
+            ],
+        ]);
+    }
+
+    public function update(Request $request, User $user): RedirectResponse
+    {
+        if ($request->user()->is($user)) {
+            return back()->with('error', 'Tu ne peux pas modifier tes propres pouvoirs.');
+        }
+
+        $validated = $request->validate([
+            'is_admin' => ['required', 'boolean'],
+        ]);
+
+        $user->forceFill([
+            'is_admin' => $validated['is_admin'],
+        ])->save();
+
+        $message = $validated['is_admin']
+            ? sprintf('%s est maintenant administrateur.', $user->name ?? $user->username)
+            : sprintf("Les droits d'administrateur de %s ont été retirés.", $user->name ?? $user->username);
+
+        return back()->with('success', $message);
+    }
+}

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -5,7 +5,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid, MessageSquare } from 'lucide-vue-next';
+import { BookOpen, Folder, LayoutGrid, MessageSquare, ShieldCheck } from 'lucide-vue-next';
 import { computed } from 'vue';
 import AppLogo from './AppLogo.vue';
 
@@ -25,6 +25,11 @@ const mainNavItems = computed<NavItem[]>(() => {
             title: 'Modération',
             href: route('admin.moderation.index'),
             icon: MessageSquare,
+        });
+        items.push({
+            title: 'Pouvoirs',
+            href: route('admin.powers.index'),
+            icon: ShieldCheck,
         });
     }
 

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,8 +1,19 @@
 <script setup lang="ts">
 import AppHeaderLayout from '@/layouts/app/AppHeaderLayout.vue';
-import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/vue3';
-import PlaceholderPattern from '../components/PlaceholderPattern.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/vue3';
+import { MessageSquare, ShieldCheck } from 'lucide-vue-next';
+import { computed, type Component } from 'vue';
+
+interface AdminAction {
+    title: string;
+    description: string;
+    href: string;
+    icon: Component;
+}
+
+const page = usePage<SharedData>();
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -10,13 +21,64 @@ const breadcrumbs: BreadcrumbItem[] = [
         href: '/',
     },
 ];
+
+const isAdmin = computed(() => page.props.auth.user?.is_admin ?? false);
+
+const adminLinks = computed<AdminAction[]>(() => [
+    {
+        title: 'Modération',
+        description: 'Gère les commentaires et les astuces en attente de validation.',
+        href: route('admin.moderation.index'),
+        icon: MessageSquare,
+    },
+    {
+        title: 'Pouvoirs',
+        description: 'Donne ou retire les droits administrateur aux membres de l’équipe.',
+        href: route('admin.powers.index'),
+        icon: ShieldCheck,
+    },
+]);
 </script>
 
 <template>
     <Head title="Dashboard" />
 
     <AppHeaderLayout :breadcrumbs="breadcrumbs">
-        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+        <div class="space-y-6 rounded-xl p-4 md:p-6">
+            <section
+                v-if="isAdmin"
+                class="space-y-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
+            >
+                <header>
+                    <h2 class="text-lg font-semibold">Menu administrateur</h2>
+                    <p class="text-sm text-gray-600 dark:text-neutral-400">
+                        Accède rapidement aux outils nécessaires pour modérer la communauté et gérer les accès.
+                    </p>
+                </header>
+
+                <div class="grid gap-4 md:grid-cols-2">
+                    <Link
+                        v-for="link in adminLinks"
+                        :key="link.title"
+                        :href="link.href"
+                        class="group flex items-start justify-between gap-4 rounded-lg border border-gray-200 bg-white p-5 transition hover:border-primary hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900"
+                    >
+                        <div class="flex items-start gap-4">
+                            <span
+                                class="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary transition group-hover:bg-primary group-hover:text-white dark:bg-primary/20"
+                            >
+                                <component :is="link.icon" class="size-5" />
+                            </span>
+                            <div class="space-y-1">
+                                <h3 class="text-sm font-semibold">{{ link.title }}</h3>
+                                <p class="text-xs text-gray-600 dark:text-neutral-400">{{ link.description }}</p>
+                            </div>
+                        </div>
+                        <span class="text-xs font-semibold text-primary transition group-hover:underline">Accéder</span>
+                    </Link>
+                </div>
+            </section>
+
             <div class="grid auto-rows-min gap-4 md:grid-cols-3">
                 <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                     <PlaceholderPattern />

--- a/resources/js/pages/admin/Powers.vue
+++ b/resources/js/pages/admin/Powers.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import type { BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+interface UserSummary {
+    id: number;
+    name: string | null;
+    username: string;
+    email: string;
+    is_admin: boolean;
+    joined_at: string | null;
+}
+
+defineProps<{
+    users: UserSummary[];
+    flash?: {
+        success?: string | null;
+        error?: string | null;
+    };
+}>();
+
+const breadcrumbs = computed<BreadcrumbItem[]>(() => [
+    {
+        title: 'Dashboard',
+        href: route('dashboard'),
+    },
+    {
+        title: 'Pouvoirs',
+        href: route('admin.powers.index'),
+    },
+]);
+
+const formatDate = (value: string | null) =>
+    value
+        ? new Intl.DateTimeFormat('fr-FR', {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+          }).format(new Date(value))
+        : '—';
+
+const toggleAdmin = (user: UserSummary) => {
+    router.patch(
+        route('admin.powers.update', user.id),
+        { is_admin: !user.is_admin },
+        {
+            preserveScroll: true,
+        },
+    );
+};
+</script>
+
+<template>
+    <Head title="Gestion des pouvoirs" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="space-y-6 p-6">
+            <div v-if="flash?.success" class="rounded-lg border border-green-300 bg-green-100 px-4 py-3 text-sm text-green-700">
+                {{ flash.success }}
+            </div>
+            <div v-if="flash?.error" class="rounded-lg border border-red-300 bg-red-100 px-4 py-3 text-sm text-red-700">
+                {{ flash.error }}
+            </div>
+
+            <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+                <header class="border-b border-gray-200 bg-gray-50 px-6 py-4 dark:border-neutral-800 dark:bg-neutral-950">
+                    <h1 class="text-lg font-semibold">Gestion des pouvoirs</h1>
+                    <p class="text-sm text-gray-600 dark:text-neutral-400">
+                        Attribue ou retire les droits administrateur des membres de la communauté.
+                    </p>
+                </header>
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200 text-left text-sm dark:divide-neutral-800">
+                        <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 dark:bg-neutral-950 dark:text-neutral-400">
+                            <tr>
+                                <th scope="col" class="px-6 py-3">Membre</th>
+                                <th scope="col" class="px-6 py-3">Rôle actuel</th>
+                                <th scope="col" class="px-6 py-3">Inscrit le</th>
+                                <th scope="col" class="px-6 py-3 text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-neutral-800">
+                            <tr v-for="user in users" :key="user.id" class="bg-white dark:bg-neutral-900">
+                                <td class="px-6 py-4">
+                                    <div class="space-y-1">
+                                        <Link :href="route('users.show', { username: user.username })" class="font-semibold hover:underline">
+                                            {{ user.username }}
+                                        </Link>
+                                        <p class="text-xs text-gray-500 dark:text-neutral-400">
+                                            {{ user.email }}
+                                        </p>
+                                    </div>
+                                </td>
+                                <td class="px-6 py-4">
+                                    <span
+                                        class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold"
+                                        :class="user.is_admin
+                                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
+                                            : 'bg-gray-100 text-gray-600 dark:bg-neutral-800 dark:text-neutral-300'"
+                                    >
+                                        {{ user.is_admin ? 'Administrateur' : 'Utilisateur' }}
+                                    </span>
+                                </td>
+                                <td class="px-6 py-4 text-sm text-gray-600 dark:text-neutral-400">
+                                    {{ formatDate(user.joined_at) }}
+                                </td>
+                                <td class="px-6 py-4 text-right">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        class="inline-flex items-center gap-2"
+                                        @click="toggleAdmin(user)"
+                                    >
+                                        {{ user.is_admin ? 'Retirer les droits' : 'Donner les droits' }}
+                                    </Button>
+                                </td>
+                            </tr>
+                            <tr v-if="users.length === 0">
+                                <td colspan="4" class="px-6 py-10 text-center text-sm text-gray-500 dark:text-neutral-400">
+                                    Aucun membre à afficher pour le moment.
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Http\Controllers\GameController;
 use App\Http\Controllers\Admin\ModerationController;
+use App\Http\Controllers\Admin\PowersController;
 use App\Http\Controllers\GameRatingController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\SubscriptionController;
@@ -44,6 +45,8 @@ Route::middleware('auth')->delete('/tips/{tip}', [TipController::class, 'destroy
 
 Route::middleware(['auth', 'admin'])->group(function () {
     Route::get('/admin/moderation', ModerationController::class)->name('admin.moderation.index');
+    Route::get('/admin/powers', [PowersController::class, 'index'])->name('admin.powers.index');
+    Route::patch('/admin/powers/{user}', [PowersController::class, 'update'])->name('admin.powers.update');
     Route::patch('/admin/comments/{comment}/approve', [CommentController::class, 'approve'])->name('admin.comments.approve');
     Route::patch('/admin/tips/{tip}/approve', [TipController::class, 'approve'])->name('admin.tips.approve');
 });


### PR DESCRIPTION
## Summary
- add an administrator quick-access section on the dashboard and expose the new "Pouvoirs" link in the sidebar
- create the powers management Inertia page with controls to grant or revoke admin rights
- register the backend controller and routes that feed the new page with user data

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the container)*
- npm run lint *(fails: existing lint errors in billing and games pages)*

------
https://chatgpt.com/codex/tasks/task_e_68da58e0dca4832cb2a6bb1f3b5ef65e