### PR TITLE
Add admin-managed announcements to dashboard

### DIFF
--- a/app/Http/Controllers/Admin/AnnouncementController.php
+++ b/app/Http/Controllers/Admin/AnnouncementController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Announcement;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AnnouncementController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $announcements = Announcement::query()
+            ->with(['user:id,name,username'])
+            ->orderByDesc('published_at')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (Announcement $announcement) => [
+                'id'           => $announcement->id,
+                'title'        => $announcement->title,
+                'content'      => $announcement->content,
+                'published_at' => $announcement->published_at?->toIso8601String(),
+                'created_at'   => $announcement->created_at?->toIso8601String(),
+                'author'       => $announcement->user?->only(['id', 'name', 'username']),
+            ]);
+
+        return Inertia::render('admin/Announcements', [
+            'announcements' => $announcements,
+            'flash' => [
+                'success' => $request->session()->get('success'),
+                'error'   => $request->session()->get('error'),
+            ],
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'title'   => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+        ]);
+
+        Announcement::create([
+            'user_id'      => $request->user()->id,
+            'title'        => $validated['title'],
+            'content'      => $validated['content'],
+            'published_at' => now(),
+        ]);
+
+        return redirect()->route('admin.announcements.index')->with('success', 'Annonce publiée avec succès.');
+    }
+
+    public function destroy(Announcement $announcement): RedirectResponse
+    {
+        $announcement->delete();
+
+        return redirect()->route('admin.announcements.index')->with('success', 'Annonce supprimée.');
+    }
+}

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Announcement extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'title',
+        'content',
+        'published_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'published_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_10_26_000000_create_announcements_table.php
+++ b/database/migrations/2025_10_26_000000_create_announcements_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('announcements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->text('content');
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('announcements');
+    }
+};

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -5,7 +5,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid, MessageSquare, ShieldCheck } from 'lucide-vue-next';
+import { BookOpen, Folder, LayoutGrid, Megaphone, MessageSquare, ShieldCheck } from 'lucide-vue-next';
 import { computed } from 'vue';
 import AppLogo from './AppLogo.vue';
 
@@ -30,6 +30,11 @@ const mainNavItems = computed<NavItem[]>(() => {
             title: 'Pouvoirs',
             href: route('admin.powers.index'),
             icon: ShieldCheck,
+        });
+        items.push({
+            title: 'Annonces',
+            href: route('admin.announcements.index'),
+            icon: Megaphone,
         });
     }
 

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -3,7 +3,7 @@ import AppHeaderLayout from '@/layouts/app/AppHeaderLayout.vue';
 import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/vue3';
-import { MessageSquare, ShieldCheck } from 'lucide-vue-next';
+import { MessageSquare, Megaphone, ShieldCheck } from 'lucide-vue-next';
 import { computed, type Component } from 'vue';
 
 interface AdminAction {
@@ -37,7 +37,23 @@ const adminLinks = computed<AdminAction[]>(() => [
         href: route('admin.powers.index'),
         icon: ShieldCheck,
     },
+    {
+        title: 'Annonces',
+        description: 'Publie des messages importants pour informer toute la communauté.',
+        href: route('admin.announcements.index'),
+        icon: Megaphone,
+    },
 ]);
+
+const currentAnnouncement = computed(() => page.props.announcement ?? null);
+
+const formatDate = (value: string | null | undefined) =>
+    value
+        ? new Intl.DateTimeFormat('fr-FR', {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+          }).format(new Date(value))
+        : null;
 </script>
 
 <template>
@@ -45,6 +61,34 @@ const adminLinks = computed<AdminAction[]>(() => [
 
     <AppHeaderLayout :breadcrumbs="breadcrumbs">
         <div class="space-y-6 rounded-xl p-4 md:p-6">
+            <section
+                v-if="currentAnnouncement"
+                class="space-y-3 rounded-xl border border-blue-200 bg-blue-50 p-6 text-blue-900 shadow-sm dark:border-blue-800/60 dark:bg-blue-950/60 dark:text-blue-100"
+            >
+                <header class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-300">
+                            Information du site
+                        </p>
+                        <h2 class="text-lg font-semibold">{{ currentAnnouncement.title }}</h2>
+                    </div>
+                    <div class="text-xs text-blue-700/80 dark:text-blue-200/80">
+                        <p v-if="currentAnnouncement.author">
+                            Posté par
+                            <span class="font-semibold">
+                                {{ currentAnnouncement.author.name ?? currentAnnouncement.author.username }}
+                            </span>
+                        </p>
+                        <p v-if="formatDate(currentAnnouncement.published_at)">
+                            {{ formatDate(currentAnnouncement.published_at) }}
+                        </p>
+                    </div>
+                </header>
+                <p class="whitespace-pre-line text-sm leading-relaxed text-blue-800 dark:text-blue-100/90">
+                    {{ currentAnnouncement.content }}
+                </p>
+            </section>
+
             <section
                 v-if="isAdmin"
                 class="space-y-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"

--- a/resources/js/pages/admin/Announcements.vue
+++ b/resources/js/pages/admin/Announcements.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import type { BreadcrumbItem, SiteAnnouncement } from '@/types';
+import { Head, router, useForm } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+interface Props {
+    announcements: SiteAnnouncement[];
+    flash?: {
+        success?: string | null;
+        error?: string | null;
+    };
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbs = computed<BreadcrumbItem[]>(() => [
+    {
+        title: 'Dashboard',
+        href: route('dashboard'),
+    },
+    {
+        title: 'Annonces',
+        href: route('admin.announcements.index'),
+    },
+]);
+
+const form = useForm({
+    title: '',
+    content: '',
+});
+
+const submit = () => {
+    form.post(route('admin.announcements.store'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            form.reset();
+        },
+    });
+};
+
+const remove = (id: number) => {
+    if (confirm('Supprimer cette annonce ?')) {
+        router.delete(route('admin.announcements.destroy', id), {
+            preserveScroll: true,
+        });
+    }
+};
+
+const latestAnnouncement = computed(() => props.announcements.at(0) ?? null);
+
+const formatDate = (value: string | null | undefined) =>
+    value
+        ? new Intl.DateTimeFormat('fr-FR', {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+          }).format(new Date(value))
+        : null;
+</script>
+
+<template>
+    <Head title="Annonces du site" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="space-y-6 p-6">
+            <div v-if="props.flash?.success" class="rounded-lg border border-green-300 bg-green-100 px-4 py-3 text-sm text-green-700">
+                {{ props.flash.success }}
+            </div>
+            <div v-if="props.flash?.error" class="rounded-lg border border-red-300 bg-red-100 px-4 py-3 text-sm text-red-700">
+                {{ props.flash.error }}
+            </div>
+
+            <section class="grid gap-6 lg:grid-cols-3">
+                <form
+                    class="space-y-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-2"
+                    @submit.prevent="submit"
+                >
+                    <header class="space-y-1">
+                        <h1 class="text-lg font-semibold">Publier une annonce</h1>
+                        <p class="text-sm text-gray-600 dark:text-neutral-400">
+                            Partage des informations importantes avec l’ensemble des membres depuis cet espace dédié.
+                        </p>
+                    </header>
+
+                    <div class="space-y-1">
+                        <label for="announcement-title" class="text-sm font-medium text-gray-700 dark:text-neutral-200">Titre</label>
+                        <input
+                            id="announcement-title"
+                            v-model="form.title"
+                            type="text"
+                            class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50"
+                            :disabled="form.processing"
+                            required
+                        />
+                        <p v-if="form.errors.title" class="text-xs text-red-500">{{ form.errors.title }}</p>
+                    </div>
+
+                    <div class="space-y-1">
+                        <label for="announcement-content" class="text-sm font-medium text-gray-700 dark:text-neutral-200">Message</label>
+                        <textarea
+                            id="announcement-content"
+                            v-model="form.content"
+                            rows="6"
+                            class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50"
+                            :disabled="form.processing"
+                            required
+                        />
+                        <p v-if="form.errors.content" class="text-xs text-red-500">{{ form.errors.content }}</p>
+                    </div>
+
+                    <div class="flex justify-end">
+                        <button
+                            type="submit"
+                            class="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-70"
+                            :disabled="form.processing"
+                        >
+                            Publier
+                        </button>
+                    </div>
+                </form>
+
+                <aside class="space-y-4 rounded-xl border border-blue-200 bg-blue-50 p-6 text-blue-900 shadow-sm dark:border-blue-800/60 dark:bg-blue-950/60 dark:text-blue-100">
+                    <header class="space-y-1">
+                        <p class="text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-300">
+                            Dernière annonce
+                        </p>
+                        <h2 class="text-lg font-semibold">
+                            {{ latestAnnouncement?.title ?? 'Aucune annonce publiée pour le moment' }}
+                        </h2>
+                    </header>
+                    <p v-if="latestAnnouncement?.author" class="text-xs text-blue-700/80 dark:text-blue-200/80">
+                        Posté par
+                        <span class="font-semibold">{{ latestAnnouncement.author.name ?? latestAnnouncement.author.username }}</span>
+                    </p>
+                    <p v-if="formatDate(latestAnnouncement?.published_at)" class="text-xs text-blue-700/80 dark:text-blue-200/80">
+                        {{ formatDate(latestAnnouncement?.published_at) }}
+                    </p>
+                    <p v-if="latestAnnouncement" class="whitespace-pre-line text-sm leading-relaxed text-blue-800 dark:text-blue-100/90">
+                        {{ latestAnnouncement.content }}
+                    </p>
+                    <p v-else class="text-sm text-blue-800/70 dark:text-blue-100/70">
+                        Publie ta première annonce pour informer la communauté.
+                    </p>
+                </aside>
+            </section>
+
+            <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+                <header class="border-b border-gray-200 bg-gray-50 px-6 py-4 dark:border-neutral-800 dark:bg-neutral-950">
+                    <h2 class="text-lg font-semibold">Historique des annonces</h2>
+                    <p class="text-sm text-gray-600 dark:text-neutral-400">
+                        Retrouve ici les messages déjà diffusés. Supprime ceux qui ne sont plus pertinents.
+                    </p>
+                </header>
+                <div class="divide-y divide-gray-200 dark:divide-neutral-800">
+                    <article
+                        v-for="announcement in announcements"
+                        :key="announcement.id"
+                        class="flex flex-col gap-4 px-6 py-5 lg:flex-row lg:items-start lg:justify-between"
+                    >
+                        <div class="space-y-2">
+                            <h3 class="text-base font-semibold text-gray-900 dark:text-neutral-100">{{ announcement.title }}</h3>
+                            <p class="whitespace-pre-line text-sm text-gray-700 dark:text-neutral-200">
+                                {{ announcement.content }}
+                            </p>
+                            <div class="text-xs text-gray-500 dark:text-neutral-400">
+                                <p v-if="announcement.author">
+                                    Publié par {{ announcement.author.name ?? announcement.author.username }}
+                                </p>
+                                <p v-if="formatDate(announcement.published_at)">
+                                    {{ formatDate(announcement.published_at) }}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <button
+                                type="button"
+                                class="rounded border border-red-200 px-4 py-2 text-sm font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/30"
+                                @click="remove(announcement.id)"
+                            >
+                                Supprimer
+                            </button>
+                        </div>
+                    </article>
+                    <p v-if="announcements.length === 0" class="px-6 py-10 text-center text-sm text-gray-500 dark:text-neutral-400">
+                        Aucune annonce n’a encore été publiée.
+                    </p>
+                </div>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -18,12 +18,25 @@ export interface NavItem {
     isActive?: boolean;
 }
 
+export interface SiteAnnouncement {
+    id: number;
+    title: string;
+    content: string;
+    published_at: string | null;
+    author: {
+        id: number;
+        name: string | null;
+        username: string;
+    } | null;
+}
+
 export interface SharedData extends PageProps {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
     ziggy: Config & { location: string };
     sidebarOpen: boolean;
+    announcement?: SiteAnnouncement | null;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- add an Announcement model, migration, and admin controller to manage site-wide messages
- surface the latest announcement on the dashboard and navigation for administrators
- build an Inertia page where admins can publish and delete announcements

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in repository checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68da6a7d3ef8832cb4322bf9bc8d721c