### PR TITLE
Add authenticated API stats endpoints

### DIFF
--- a/app/Http/Controllers/API/StatsController.php
+++ b/app/Http/Controllers/API/StatsController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Comment;
+use App\Models\Game;
+use App\Models\GameRating;
+use App\Models\Tip;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+
+class StatsController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $ratingsCount = GameRating::count();
+
+        $ratingsAverage = null;
+
+        if ($ratingsCount > 0) {
+            $ratingsAverage = round((float) GameRating::avg('rating'), 1);
+        }
+
+        return response()->json([
+            'games' => [
+                'total' => Game::count(),
+                'rated_total' => GameRating::query()->distinct()->count('game_id'),
+            ],
+            'ratings' => [
+                'total' => $ratingsCount,
+                'average' => $ratingsAverage,
+            ],
+            'comments' => [
+                'approved_total' => Comment::approved()->count(),
+            ],
+            'tips' => [
+                'approved_total' => Tip::approved()->count(),
+            ],
+            'users' => [
+                'total' => User::count(),
+            ],
+        ]);
+    }
+
+    public function gameRating(Game $game): JsonResponse
+    {
+        $ratingsCount = $game->ratings()->count();
+
+        $averageRating = null;
+
+        if ($ratingsCount > 0) {
+            $averageRating = round((float) $game->ratings()->avg('rating'), 1);
+        }
+
+        return response()->json([
+            'game_id' => $game->id,
+            'average_rating' => $averageRating,
+            'ratings_count' => $ratingsCount,
+        ]);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/database/factories/GameRatingFactory.php
+++ b/database/factories/GameRatingFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Game;
+use App\Models\GameRating;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<GameRating>
+ */
+class GameRatingFactory extends Factory
+{
+    protected $model = GameRating::class;
+
+    public function definition(): array
+    {
+        return [
+            'game_id' => Game::factory(),
+            'user_id' => User::factory(),
+            'rating' => $this->faker->numberBetween(1, 10),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Http\Controllers\API\StatsController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('api')
+    ->middleware(['api', 'auth'])
+    ->name('api.')
+    ->group(function () {
+        Route::get('stats', [StatsController::class, 'index'])->name('stats');
+        Route::get('games/{game}/rating', [StatsController::class, 'gameRating'])->name('games.rating');
+    });

--- a/tests/Feature/Api/StatsTest.php
+++ b/tests/Feature/Api/StatsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Comment;
+use App\Models\Game;
+use App\Models\GameRating;
+use App\Models\Tip;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_access_stats_endpoint(): void
+    {
+        $this->getJson('/api/stats')->assertUnauthorized();
+    }
+
+    public function test_guest_cannot_access_game_rating_endpoint(): void
+    {
+        $game = Game::factory()->create();
+
+        $this->getJson("/api/games/{$game->id}/rating")->assertUnauthorized();
+    }
+
+    public function test_stats_endpoint_returns_aggregated_metrics(): void
+    {
+        $user = User::factory()->create();
+        $anotherUser = User::factory()->create();
+
+        $gameA = Game::factory()->create();
+        $gameB = Game::factory()->create();
+
+        GameRating::factory()->for($gameA, 'game')->for($user, 'user')->create(['rating' => 8]);
+        GameRating::factory()->for($gameA, 'game')->for($anotherUser, 'user')->create(['rating' => 6]);
+        GameRating::factory()->for($gameB, 'game')->for($user, 'user')->create(['rating' => 7]);
+
+        Comment::factory()->for($gameA, 'game')->for($user, 'user')->create();
+        Comment::factory()->for($gameB, 'game')->for($anotherUser, 'user')->create();
+        Comment::factory()->for($gameA, 'game')->for($user, 'user')->create(['is_approved' => false]);
+
+        Tip::factory()->for($gameA, 'game')->for($user, 'user')->create();
+        Tip::factory()->for($gameB, 'game')->for($anotherUser, 'user')->create(['is_approved' => false]);
+
+        $response = $this->actingAs($user)->getJson('/api/stats');
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'games' => [
+                    'total' => 2,
+                    'rated_total' => 2,
+                ],
+                'ratings' => [
+                    'total' => 3,
+                    'average' => 7.0,
+                ],
+                'comments' => [
+                    'approved_total' => 2,
+                ],
+                'tips' => [
+                    'approved_total' => 1,
+                ],
+                'users' => [
+                    'total' => 2,
+                ],
+            ]);
+    }
+
+    public function test_game_rating_endpoint_returns_average_and_count(): void
+    {
+        $user = User::factory()->create();
+        $anotherUser = User::factory()->create();
+        $game = Game::factory()->create();
+
+        GameRating::factory()->for($game, 'game')->for($user, 'user')->create(['rating' => 8]);
+        GameRating::factory()->for($game, 'game')->for($anotherUser, 'user')->create(['rating' => 7]);
+
+        $response = $this->actingAs($user)->getJson("/api/games/{$game->id}/rating");
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'game_id' => $game->id,
+                'average_rating' => 7.5,
+                'ratings_count' => 2,
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- register the API routes file in the application bootstrap so JSON endpoints are available
- add an API stats controller that aggregates games, ratings, comments, tips, and user metrics
- expose authenticated routes for stats and per-game ratings with supporting factories and feature tests

## Testing
- not run (unable to install dependencies due to external network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68da8fb8efd0832cad0615aa42425e85