### PR TITLE
Implement dashboard stats fetching and display

### DIFF
--- a/resources/js/lib/stats.ts
+++ b/resources/js/lib/stats.ts
@@ -1,0 +1,36 @@
+export interface DashboardStats {
+    games: {
+        total: number;
+        rated_total: number;
+    };
+    ratings: {
+        total: number;
+        average: number | null;
+    };
+    comments: {
+        approved_total: number;
+    };
+    tips: {
+        approved_total: number;
+    };
+    users: {
+        total: number;
+    };
+}
+
+export const fetchDashboardStats = async (): Promise<DashboardStats> => {
+    const response = await fetch(route('api.stats'), {
+        headers: {
+            Accept: 'application/json',
+        },
+        credentials: 'same-origin',
+    });
+
+    if (!response.ok) {
+        throw new Error("Impossible de récupérer les statistiques du tableau de bord.");
+    }
+
+    const payload = (await response.json()) as DashboardStats;
+
+    return payload;
+};


### PR DESCRIPTION
## Summary
- add a typed helper that fetches dashboard statistics from the API route
- load and store statistics on the dashboard with loading and error handling
- render community metrics in place of placeholder panels

## Testing
- `npm run lint` *(fails: pre-existing lint errors in billing and games pages)*

------
https://chatgpt.com/codex/tasks/task_e_68da94f50d54832c9312548acdde01c2