### PR TITLE
Fix CSRF handling for Inertia requests

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,3 +1,4 @@
+import './bootstrap';
 import '../css/app.css';
 
 import { createInertiaApp } from '@inertiajs/vue3';

--- a/resources/js/bootstrap.ts
+++ b/resources/js/bootstrap.ts
@@ -1,0 +1,12 @@
+import { router } from '@inertiajs/vue3';
+
+const token = document.head.querySelector<HTMLMetaElement>('meta[name="csrf-token"]');
+
+if (token) {
+    router.on('before', (event) => {
+        event.detail.visit.headers['X-CSRF-TOKEN'] = token.content;
+        event.detail.visit.headers['X-Requested-With'] = 'XMLHttpRequest';
+    });
+} else {
+    console.warn('CSRF token not found. Inertia requests may be rejected.');
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>


### PR DESCRIPTION
## Summary
- expose the Laravel CSRF token in the Inertia root view
- hook into the Inertia router to attach CSRF and XHR headers to every request
- ensure the new bootstrap script is loaded before the Vue application

## Testing
- npm run lint *(fails: existing lint violations in billing and games pages)*

------
https://chatgpt.com/codex/tasks/task_e_68daa1e5deb8832ca06ecb90c6b72391