### PR TITLE
Implement Sanctum token endpoints for API authentication

### DIFF
--- a/app/Http/Controllers/API/AuthTokenController.php
+++ b/app/Http/Controllers/API/AuthTokenController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ApiTokenRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AuthTokenController extends Controller
+{
+    /**
+     * Exchange valid credentials for a Sanctum personal access token.
+     */
+    public function store(ApiTokenRequest $request): JsonResponse
+    {
+        $user = $request->resolveUser();
+
+        $tokenName = $request->string('device_name')->isNotEmpty()
+            ? $request->string('device_name')->toString()
+            : ($request->userAgent() ?? 'api-token');
+
+        $token = $user->createToken($tokenName);
+
+        return response()->json([
+            'token' => $token->plainTextToken,
+            'token_type' => 'Bearer',
+        ]);
+    }
+
+    /**
+     * Revoke the currently authenticated access token.
+     */
+    public function destroy(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()?->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Auth/ApiTokenRequest.php
+++ b/app/Http/Requests/Auth/ApiTokenRequest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use App\Models\User;
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class ApiTokenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+            'device_name' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * Attempt to resolve the authenticated user for the token request.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function resolveUser(): User
+    {
+        $this->ensureIsNotRateLimited();
+
+        $user = User::query()
+            ->where('email', $this->string('email'))
+            ->first();
+
+        if (! $user || ! Hash::check($this->string('password'), $user->password)) {
+            RateLimiter::hit($this->throttleKey());
+
+            throw ValidationException::withMessages([
+                'email' => trans('auth.failed'),
+            ]);
+        }
+
+        RateLimiter::clear($this->throttleKey());
+
+        return $user;
+    }
+
+    /**
+     * Ensure the login request is not rate limited.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    protected function ensureIsNotRateLimited(): void
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        event(new Lockout($this));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'email' => trans('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => (int) ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    /**
+     * Get the rate limiting throttle key for the request.
+     */
+    public function throttleKey(): string
+    {
+        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -14,7 +14,7 @@ return [
     */
 
     'defaults' => [
-        'guard' => env('AUTH_GUARD', 'sanctum'),
+        'guard' => env('AUTH_GUARD', 'web'),
         'passwords' => env('AUTH_PASSWORD_BROKER', 'users'),
     ],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,12 +1,19 @@
 <?php
 
+use App\Http\Controllers\API\AuthTokenController;
 use App\Http\Controllers\API\StatsController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('api')
-    ->middleware(['api', 'auth:sanctum'])
+    ->middleware(['api'])
     ->name('api.')
     ->group(function () {
-        Route::get('stats', [StatsController::class, 'index'])->name('stats');
-        Route::get('games/{game}/rating', [StatsController::class, 'gameRating'])->name('games.rating');
+        Route::post('auth/token', [AuthTokenController::class, 'store'])->name('auth.token.store');
+
+        Route::middleware('auth:sanctum')->group(function () {
+            Route::delete('auth/token', [AuthTokenController::class, 'destroy'])->name('auth.token.destroy');
+
+            Route::get('stats', [StatsController::class, 'index'])->name('stats');
+            Route::get('games/{game}/rating', [StatsController::class, 'gameRating'])->name('games.rating');
+        });
     });

--- a/tests/Feature/Api/AuthTokenTest.php
+++ b/tests/Feature/Api/AuthTokenTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_exchange_credentials_for_token(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret-password'),
+        ]);
+
+        $response = $this->postJson('/api/auth/token', [
+            'email' => $user->email,
+            'password' => 'secret-password',
+            'device_name' => 'cli',
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure(['token', 'token_type']);
+
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+            'tokenable_type' => User::class,
+            'name' => 'cli',
+        ]);
+    }
+
+    public function test_invalid_credentials_return_validation_error(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret-password'),
+        ]);
+
+        $response = $this->postJson('/api/auth/token', [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $response
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('email');
+    }
+
+    public function test_authenticated_user_can_revoke_current_token(): void
+    {
+        $user = User::factory()->create();
+
+        $token = $user->createToken('test-device');
+        $plainTextToken = $token->plainTextToken;
+        $tokenId = $token->accessToken->id;
+
+        $response = $this->withToken($plainTextToken)->deleteJson('/api/auth/token');
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'id' => $tokenId,
+        ]);
+    }
+}

--- a/tests/Feature/Api/StatsTest.php
+++ b/tests/Feature/Api/StatsTest.php
@@ -8,6 +8,7 @@ use App\Models\GameRating;
 use App\Models\Tip;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class StatsTest extends TestCase
@@ -45,7 +46,9 @@ class StatsTest extends TestCase
         Tip::factory()->for($gameA, 'game')->for($user, 'user')->create();
         Tip::factory()->for($gameB, 'game')->for($anotherUser, 'user')->create(['is_approved' => false]);
 
-        $response = $this->actingAs($user)->getJson('/api/stats');
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/stats');
 
         $response
             ->assertOk()
@@ -79,7 +82,9 @@ class StatsTest extends TestCase
         GameRating::factory()->for($game, 'game')->for($user, 'user')->create(['rating' => 8]);
         GameRating::factory()->for($game, 'game')->for($anotherUser, 'user')->create(['rating' => 7]);
 
-        $response = $this->actingAs($user)->getJson("/api/games/{$game->id}/rating");
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson("/api/games/{$game->id}/rating");
 
         $response
             ->assertOk()


### PR DESCRIPTION
## Summary
- add a dedicated controller and request to exchange credentials for Sanctum personal access tokens
- protect existing API routes with the Sanctum guard and expose a token revocation endpoint
- cover the new token workflow and existing statistics endpoints with Sanctum-based feature tests

## Testing
- php artisan test *(fails: vendor directory not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db95b729e4832cb755ba006187ea8d