### PR TITLE
Share dashboard stats directly with the dashboard view

### DIFF
--- a/app/Actions/Dashboard/GetDashboardStats.php
+++ b/app/Actions/Dashboard/GetDashboardStats.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Actions\Dashboard;
+
+use App\Models\Comment;
+use App\Models\Game;
+use App\Models\GameRating;
+use App\Models\Tip;
+use App\Models\User;
+
+class GetDashboardStats
+{
+    /**
+     * @return array{
+     *     games: array{total: int, rated_total: int},
+     *     ratings: array{total: int, average: float|null},
+     *     comments: array{approved_total: int},
+     *     tips: array{approved_total: int},
+     *     users: array{total: int},
+     * }
+     */
+    public function handle(): array
+    {
+        $ratingsCount = GameRating::count();
+
+        $ratingsAverage = null;
+
+        if ($ratingsCount > 0) {
+            $ratingsAverage = round((float) GameRating::avg('rating'), 1);
+        }
+
+        return [
+            'games' => [
+                'total' => Game::count(),
+                'rated_total' => GameRating::query()->distinct()->count('game_id'),
+            ],
+            'ratings' => [
+                'total' => $ratingsCount,
+                'average' => $ratingsAverage,
+            ],
+            'comments' => [
+                'approved_total' => Comment::approved()->count(),
+            ],
+            'tips' => [
+                'approved_total' => Tip::approved()->count(),
+            ],
+            'users' => [
+                'total' => User::count(),
+            ],
+        ];
+    }
+}
+

--- a/app/Http/Controllers/API/StatsController.php
+++ b/app/Http/Controllers/API/StatsController.php
@@ -2,46 +2,21 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Actions\Dashboard\GetDashboardStats;
 use App\Http\Controllers\Controller;
-use App\Models\Comment;
 use App\Models\Game;
-use App\Models\GameRating;
-use App\Models\Tip;
-use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class StatsController extends Controller
 {
+    public function __construct(private readonly GetDashboardStats $getDashboardStats)
+    {
+    }
+
     public function index(): JsonResponse
     {
-        $ratingsCount = GameRating::count();
-
-        $ratingsAverage = null;
-
-        if ($ratingsCount > 0) {
-            $ratingsAverage = round((float) GameRating::avg('rating'), 1);
-        }
-
-        return response()->json([
-            'games' => [
-                'total' => Game::count(),
-                'rated_total' => GameRating::query()->distinct()->count('game_id'),
-            ],
-            'ratings' => [
-                'total' => $ratingsCount,
-                'average' => $ratingsAverage,
-            ],
-            'comments' => [
-                'approved_total' => Comment::approved()->count(),
-            ],
-            'tips' => [
-                'approved_total' => Tip::approved()->count(),
-            ],
-            'users' => [
-                'total' => User::count(),
-            ],
-        ]);
+        return response()->json($this->getDashboardStats->handle());
     }
 
     public function gameRating(Request $request): JsonResponse

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -4,7 +4,7 @@ import { fetchDashboardStats, type DashboardStats } from '@/lib/stats';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/vue3';
 import { MessageSquare, Megaphone, ShieldCheck } from 'lucide-vue-next';
-import { computed, onMounted, ref, type Component } from 'vue';
+import { computed, onMounted, ref, watch, type Component } from 'vue';
 
 interface AdminAction {
     title: string;
@@ -21,7 +21,7 @@ interface RecentDashboardGame {
     searched_at: string | null;
 }
 
-const page = usePage<SharedData & { recentGames?: RecentDashboardGame[] }>();
+const page = usePage<SharedData & { recentGames?: RecentDashboardGame[]; stats?: DashboardStats }>();
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -58,8 +58,9 @@ const adminLinks = computed<AdminAction[]>(() => [
 
 const currentAnnouncement = computed(() => page.props.announcement ?? null);
 
-const stats = ref<DashboardStats | null>(null);
-const isStatsLoading = ref(false);
+const sharedStats = computed(() => page.props.stats ?? null);
+const stats = ref<DashboardStats | null>(sharedStats.value);
+const isStatsLoading = ref(!stats.value);
 const statsError = ref<string | null>(null);
 
 const loadStats = async () => {
@@ -79,7 +80,15 @@ const loadStats = async () => {
 };
 
 onMounted(() => {
-    void loadStats();
+    if (!stats.value) {
+        void loadStats();
+    }
+});
+
+watch(sharedStats, (value) => {
+    if (value) {
+        stats.value = value;
+    }
 });
 
 const formatDate = (value: string | null | undefined) =>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\Dashboard\GetDashboardStats;
 use App\Http\Controllers\UserProfileController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -48,6 +49,8 @@ $dashboardPage = function (Request $request) {
         ->values()
         ->all();
 
+    $stats = app(GetDashboardStats::class)->handle();
+
     return Inertia::render('Dashboard', [
         'isSubscribed'  => $subscription?->active() ?? false,
         'onGracePeriod' => $subscription?->onGracePeriod() ?? false,
@@ -60,6 +63,7 @@ $dashboardPage = function (Request $request) {
             'author'       => $announcement->user?->only(['id', 'name', 'username']),
         ] : null,
         'recentGames'   => $recentGames,
+        'stats'         => $stats,
     ]);
 };
 


### PR DESCRIPTION
## Summary
- extract dashboard statistics aggregation into a reusable action
- reuse the new action in the stats API and share the metrics with the dashboard page
- hydrate the dashboard component with server-provided metrics and only fetch when needed

## Testing
- ⚠️ `php artisan test --filter=StatsTest` *(fails: vendor/autoload.php missing because composer dependencies are not installed in the environment)*
- ⚠️ `composer install` *(fails: lock file missing required packages such as laravel/sanctum)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd0b953dc832c84f1f58e44ac8075