### PR TITLE
Add security headers middleware and configuration

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        /** @var Response $response */
+        $response = $next($request);
+
+        $this->addStrictTransportSecurityHeader($request, $response);
+        $this->addFrameOptionsHeader($response);
+        $this->addContentTypeOptionsHeader($response);
+        $this->addReferrerPolicyHeader($response);
+        $this->addContentSecurityPolicyHeader($response);
+
+        return $response;
+    }
+
+    protected function addStrictTransportSecurityHeader(Request $request, Response $response): void
+    {
+        $config = config('security.hsts');
+
+        if (!($config['enabled'] ?? true)) {
+            return;
+        }
+
+        $parts = [sprintf('max-age=%d', $config['max_age'] ?? 0)];
+
+        if ($config['include_subdomains'] ?? false) {
+            $parts[] = 'includeSubDomains';
+        }
+
+        if ($config['preload'] ?? false) {
+            $parts[] = 'preload';
+        }
+
+        $response->headers->set('Strict-Transport-Security', implode('; ', $parts));
+    }
+
+    protected function addFrameOptionsHeader(Response $response): void
+    {
+        $value = config('security.x_frame_options', 'SAMEORIGIN');
+
+        $response->headers->set('X-Frame-Options', $value);
+    }
+
+    protected function addContentTypeOptionsHeader(Response $response): void
+    {
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+    }
+
+    protected function addReferrerPolicyHeader(Response $response): void
+    {
+        $response->headers->set('Referrer-Policy', config('security.referrer_policy', 'strict-origin-when-cross-origin'));
+    }
+
+    protected function addContentSecurityPolicyHeader(Response $response): void
+    {
+        $csp = config('security.csp', []);
+
+        if (empty($csp)) {
+            return;
+        }
+
+        $directives = [];
+
+        foreach ($csp as $directive => $values) {
+            if (empty($values)) {
+                continue;
+            }
+
+            $directives[] = trim(sprintf('%s %s', $directive, implode(' ', array_unique($values))));
+        }
+
+        if (!empty($directives)) {
+            $response->headers->set('Content-Security-Policy', implode('; ', $directives));
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\EnsureUserIsAdmin;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -23,11 +24,16 @@ return Application::configure(basePath: dirname(__DIR__))
             'stripe/*',
         ]);
 
-        $middleware->web(append: [
-            HandleAppearance::class,
-            HandleInertiaRequests::class,
-            AddLinkHeadersForPreloadedAssets::class,
-        ]);
+        $middleware->web(
+            prepend: [
+                SecurityHeaders::class,
+            ],
+            append: [
+                HandleAppearance::class,
+                HandleInertiaRequests::class,
+                AddLinkHeadersForPreloadedAssets::class,
+            ],
+        );
 
         $middleware->api(prepend: [
             EnsureFrontendRequestsAreStateful::class,

--- a/config/security.php
+++ b/config/security.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    'hsts' => [
+        'enabled' => true,
+        'max_age' => 63_072_000,
+        'include_subdomains' => true,
+        'preload' => true,
+    ],
+
+    'x_frame_options' => 'SAMEORIGIN',
+
+    'referrer_policy' => 'strict-origin-when-cross-origin',
+
+    'csp' => [
+        'default-src' => [
+            "'self'",
+        ],
+        'script-src' => [
+            "'self'",
+            'https://js.stripe.com',
+            'https://*.stripe.com',
+            'https://*.deepl.com',
+            'https://*.deeplapi.com',
+            'http://localhost:5173',
+            'https://localhost:5173',
+        ],
+        'style-src' => [
+            "'self'",
+            "'unsafe-inline'",
+            'http://localhost:5173',
+            'https://localhost:5173',
+        ],
+        'frame-src' => [
+            "'self'",
+            'https://js.stripe.com',
+            'https://hooks.stripe.com',
+            'https://checkout.stripe.com',
+        ],
+    ],
+];

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,5 @@
+# Guide de déploiement
+
+## Sécuriser le transport TLS
+
+Activez TLS sur l'environnement de production (HTTPS avec un certificat valide) avant d'activer la redirection publique. Les en-têtes HSTS et la politique de sécurité du contenu fournis par `App\\Http\\Middleware\\SecurityHeaders` ne sont pris en compte que sur des connexions sécurisées : vérifiez donc que le certificat et la chaîne intermédiaire sont correctement installés et que les terminaux acceptent les suites TLS récentes.

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,21 @@
+<?php
+
+it('adds security headers to standard responses', function () {
+    $response = $this->get('/');
+
+    $response->assertOk();
+
+    $response->assertHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+    $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
+    $response->assertHeader('X-Content-Type-Options', 'nosniff');
+    $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+    $csp = config('security.csp');
+
+    $expected = collect($csp)
+        ->filter(fn ($values) => !empty($values))
+        ->map(fn ($values, $directive) => $directive.' '.implode(' ', array_unique($values)))
+        ->implode('; ');
+
+    $response->assertHeader('Content-Security-Policy', $expected);
+});


### PR DESCRIPTION
## Summary
- add a global SecurityHeaders middleware that enforces HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and CSP
- introduce a dedicated security configuration file to centralize CSP whitelists for Vite, Stripe, and DeepL domains
- cover the middleware with HTTP feature tests and document the TLS requirement in the deployment guide

## Testing
- php artisan test *(fails: missing vendor/autoload.php because Composer dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dbedcb75b4832c9bbf82193c077fb7