### PR TITLE
Relax CSP for local dev tooling

### DIFF
--- a/config/security.php
+++ b/config/security.php
@@ -18,18 +18,26 @@ return [
         ],
         'script-src' => [
             "'self'",
+            "'unsafe-inline'",
             'https://js.stripe.com',
             'https://*.stripe.com',
             'https://*.deepl.com',
             'https://*.deeplapi.com',
             'http://localhost:5173',
             'https://localhost:5173',
+            'http://[::1]:5173',
+            'https://[::1]:5173',
         ],
         'style-src' => [
             "'self'",
             "'unsafe-inline'",
             'http://localhost:5173',
             'https://localhost:5173',
+            'https://fonts.bunny.net',
+        ],
+        'font-src' => [
+            "'self'",
+            'https://fonts.bunny.net',
         ],
         'frame-src' => [
             "'self'",


### PR DESCRIPTION
## Summary
- allow inline scripts and IPv6 localhost dev server URLs in the CSP script-src directive to unblock Vite
- whitelist Bunny Fonts for style and font requests used by the app

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68dcde5a5ddc832c88e628f5ad920141