### PR TITLE
Limit security headers to production environments

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -13,6 +13,10 @@ class SecurityHeaders
         /** @var Response $response */
         $response = $next($request);
 
+        if (! $this->shouldApplySecurityHeaders()) {
+            return $response;
+        }
+
         $this->addStrictTransportSecurityHeader($request, $response);
         $this->addFrameOptionsHeader($response);
         $this->addContentTypeOptionsHeader($response);
@@ -20,6 +24,17 @@ class SecurityHeaders
         $this->addContentSecurityPolicyHeader($response);
 
         return $response;
+    }
+
+    protected function shouldApplySecurityHeaders(): bool
+    {
+        $environments = config('security.environments', []);
+
+        if (empty($environments)) {
+            return true;
+        }
+
+        return app()->environment($environments);
     }
 
     protected function addStrictTransportSecurityHeader(Request $request, Response $response): void

--- a/config/security.php
+++ b/config/security.php
@@ -1,6 +1,11 @@
 <?php
 
 return [
+    'environments' => [
+        'production',
+        'testing',
+    ],
+
     'hsts' => [
         'enabled' => true,
         'max_age' => 63_072_000,


### PR DESCRIPTION
## Summary
- introduce an environment allow-list to the security headers configuration
- skip applying custom security headers when the current environment is not production/testing to avoid CSP issues during local development

## Testing
- php artisan test tests/Feature/SecurityHeadersTest.php *(fails: missing vendor dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcea2abb44832c88b5445cda971bee