### PR TITLE
Add footer to the application layouts

### DIFF
--- a/resources/js/components/AppFooter.vue
+++ b/resources/js/components/AppFooter.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import AppLogo from '@/components/AppLogo.vue';
+import { Link } from '@inertiajs/vue3';
+
+interface FooterLink {
+    title: string;
+    href: string;
+}
+
+const footerLinks: FooterLink[] = [
+    {
+        title: 'Accueil',
+        href: '/',
+    },
+    {
+        title: 'Jeux',
+        href: '/games',
+    },
+    {
+        title: 'Information',
+        href: '/information',
+    },
+    {
+        title: 'Présentation',
+        href: '/presentation',
+    },
+];
+
+const currentYear = new Date().getFullYear();
+</script>
+
+<template>
+    <footer class="mt-auto border-t border-primary/30 bg-primary text-primary-foreground">
+        <div class="mx-auto w-full max-w-7xl px-4 py-10">
+            <div class="flex flex-col gap-10 md:flex-row md:items-start md:justify-between">
+                <div class="flex flex-col gap-4 text-sm text-primary-foreground/80">
+                    <Link :href="route('home')" class="flex items-center gap-3 text-base font-semibold">
+                        <AppLogo />
+                        <span class="sr-only">Retour à l'accueil</span>
+                    </Link>
+                    <p>
+                        Mentions légales : LevelUp est un espace communautaire dédié à la découverte et au partage de jeux vidéo.
+                        Toutes les informations présentées sont fournies à titre indicatif.
+                    </p>
+                </div>
+                <div>
+                    <h2 class="text-sm font-semibold uppercase tracking-wide text-primary-foreground">Navigation</h2>
+                    <ul class="mt-4 flex flex-col gap-2 text-sm">
+                        <li v-for="item in footerLinks" :key="item.title">
+                            <Link :href="item.href" class="transition hover:text-white/90">
+                                {{ item.title }}
+                            </Link>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="mt-10 flex flex-col gap-4 border-t border-white/30 pt-6 text-sm text-primary-foreground/80 md:flex-row md:items-center md:justify-between">
+                <p>© {{ currentYear }} LevelUp. Tous droits réservés.</p>
+                <Link :href="'/mentions-legales'" class="underline underline-offset-4 transition hover:text-white">
+                    Mentions légales
+                </Link>
+            </div>
+        </div>
+    </footer>
+</template>

--- a/resources/js/layouts/app/AppHeaderLayout.vue
+++ b/resources/js/layouts/app/AppHeaderLayout.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import AppContent from '@/components/AppContent.vue';
+import AppFooter from '@/components/AppFooter.vue';
 import AppHeader from '@/components/AppHeader.vue';
 import AppShell from '@/components/AppShell.vue';
 import type { BreadcrumbItemType } from '@/types';
@@ -19,5 +20,6 @@ withDefaults(defineProps<Props>(), {
         <AppContent>
             <slot />
         </AppContent>
+        <AppFooter />
     </AppShell>
 </template>

--- a/resources/js/layouts/app/AppSidebarLayout.vue
+++ b/resources/js/layouts/app/AppSidebarLayout.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import AppContent from '@/components/AppContent.vue';
+import AppFooter from '@/components/AppFooter.vue';
 import AppHeader from '@/components/AppHeader.vue';
 import AppShell from '@/components/AppShell.vue';
 import AppSidebar from '@/components/AppSidebar.vue';
@@ -26,6 +27,7 @@ withDefaults(defineProps<Props>(), {
                     <slot />
                 </AppContent>
             </div>
+            <AppFooter />
         </div>
     </AppShell>
 </template>


### PR DESCRIPTION
## Summary
- create an AppFooter component that displays the site branding, legal mention, and navigation links
- render the new footer inside the header- and sidebar-based application layouts so it appears across the site

## Testing
- npm run build *(fails: vendor/tightenco/ziggy missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf5a74a04832c9d38ec3828488f33