### PR TITLE
Add RESTful API endpoints for game ratings

### DIFF
--- a/app/Http/Controllers/API/GameRatingController.php
+++ b/app/Http/Controllers/API/GameRatingController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Game;
+use App\Models\GameRating;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\Response;
+
+class GameRatingController extends Controller
+{
+    private const RATINGS_UNAVAILABLE_MESSAGE = 'Les notes ne sont pas disponibles pour le moment. Veuillez réessayer plus tard.';
+
+    public function show(Request $request, Game $game): JsonResponse
+    {
+        $this->ensureRatingsTableExists();
+
+        $rating = GameRating::query()
+            ->where('game_id', $game->id)
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if ($rating === null) {
+            return response()->json([
+                'message' => 'Aucune note trouvée pour ce jeu.',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        return response()->json([
+            'game_id' => $rating->game_id,
+            'user_id' => $rating->user_id,
+            'rating' => $rating->rating,
+            'created_at' => $rating->created_at,
+            'updated_at' => $rating->updated_at,
+        ]);
+    }
+
+    public function store(Request $request, Game $game): JsonResponse
+    {
+        $this->ensureRatingsTableExists();
+
+        $validated = $this->validateRating($request);
+
+        $userId = $request->user()->id;
+
+        $existingRating = GameRating::query()
+            ->where('game_id', $game->id)
+            ->where('user_id', $userId)
+            ->first();
+
+        if ($existingRating !== null) {
+            return response()->json([
+                'message' => 'Une note existe déjà pour ce jeu. Utilisez PUT pour la modifier.',
+            ], Response::HTTP_CONFLICT);
+        }
+
+        $rating = GameRating::create([
+            'game_id' => $game->id,
+            'user_id' => $userId,
+            'rating' => $validated['rating'],
+        ]);
+
+        return response()->json([
+            'game_id' => $rating->game_id,
+            'user_id' => $rating->user_id,
+            'rating' => $rating->rating,
+            'created_at' => $rating->created_at,
+            'updated_at' => $rating->updated_at,
+        ], Response::HTTP_CREATED);
+    }
+
+    public function update(Request $request, Game $game): JsonResponse
+    {
+        $this->ensureRatingsTableExists();
+
+        $validated = $this->validateRating($request);
+
+        $rating = GameRating::query()
+            ->where('game_id', $game->id)
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if ($rating === null) {
+            return response()->json([
+                'message' => 'Aucune note trouvée pour ce jeu.',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        $rating->update([
+            'rating' => $validated['rating'],
+        ]);
+
+        return response()->json([
+            'game_id' => $rating->game_id,
+            'user_id' => $rating->user_id,
+            'rating' => $rating->rating,
+            'created_at' => $rating->created_at,
+            'updated_at' => $rating->updated_at,
+        ]);
+    }
+
+    public function destroy(Request $request, Game $game): JsonResponse
+    {
+        $this->ensureRatingsTableExists();
+
+        $rating = GameRating::query()
+            ->where('game_id', $game->id)
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if ($rating === null) {
+            return response()->json([
+                'message' => 'Aucune note trouvée pour ce jeu.',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        $rating->delete();
+
+        return response()->json(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function validateRating(Request $request): array
+    {
+        return $request->validate([
+            'rating' => ['required', 'integer', 'min:1', 'max:10'],
+        ]);
+    }
+
+    private function ensureRatingsTableExists(): void
+    {
+        if (! Schema::hasTable('game_ratings')) {
+            throw ValidationException::withMessages([
+                'rating' => self::RATINGS_UNAVAILABLE_MESSAGE,
+            ]);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\API\AuthTokenController;
+use App\Http\Controllers\API\GameRatingController as ApiGameRatingController;
 use App\Http\Controllers\API\StatsController;
 use Illuminate\Support\Facades\Route;
 
@@ -12,6 +13,13 @@ Route::name('api.')->group(function () {
 
         Route::get('stats', [StatsController::class, 'index'])->name('stats');
         Route::get('games/rating', [StatsController::class, 'gameRating'])->name('games.rating');
+
+        Route::prefix('games/{game}')->group(function () {
+            Route::get('rating', [ApiGameRatingController::class, 'show'])->name('games.ratings.show');
+            Route::post('rating', [ApiGameRatingController::class, 'store'])->name('games.ratings.store');
+            Route::put('rating', [ApiGameRatingController::class, 'update'])->name('games.ratings.update');
+            Route::delete('rating', [ApiGameRatingController::class, 'destroy'])->name('games.ratings.destroy');
+        });
 
     });
 });

--- a/tests/Feature/Api/GameRatingTest.php
+++ b/tests/Feature/Api/GameRatingTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Game;
+use App\Models\GameRating;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class GameRatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_manage_game_ratings(): void
+    {
+        $game = Game::factory()->create();
+
+        $this->getJson(route('api.games.ratings.show', $game))->assertUnauthorized();
+        $this->postJson(route('api.games.ratings.store', $game), ['rating' => 5])->assertUnauthorized();
+        $this->putJson(route('api.games.ratings.update', $game), ['rating' => 6])->assertUnauthorized();
+        $this->deleteJson(route('api.games.ratings.destroy', $game))->assertUnauthorized();
+    }
+
+    public function test_user_can_create_game_rating(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $game = Game::factory()->create();
+
+        $response = $this->postJson(route('api.games.ratings.store', $game), ['rating' => 7]);
+
+        $response
+            ->assertCreated()
+            ->assertJson([
+                'game_id' => $game->id,
+                'user_id' => $user->id,
+                'rating' => 7,
+            ]);
+
+        $this->assertDatabaseHas('game_ratings', [
+            'game_id' => $game->id,
+            'user_id' => $user->id,
+            'rating' => 7,
+        ]);
+    }
+
+    public function test_user_cannot_create_multiple_ratings_for_same_game(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $game = Game::factory()->create();
+
+        GameRating::factory()->for($game, 'game')->for($user, 'user')->create(['rating' => 5]);
+
+        $response = $this->postJson(route('api.games.ratings.store', $game), ['rating' => 8]);
+
+        $response
+            ->assertStatus(Response::HTTP_CONFLICT)
+            ->assertJson([
+                'message' => 'Une note existe déjà pour ce jeu. Utilisez PUT pour la modifier.',
+            ]);
+    }
+
+    public function test_user_can_view_own_game_rating(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $game = Game::factory()->create();
+
+        GameRating::factory()->for($game, 'game')->for($user, 'user')->create(['rating' => 9]);
+
+        $response = $this->getJson(route('api.games.ratings.show', $game));
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'game_id' => $game->id,
+                'user_id' => $user->id,
+                'rating' => 9,
+            ]);
+    }
+
+    public function test_show_returns_not_found_when_rating_is_missing(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $game = Game::factory()->create();
+
+        $this->getJson(route('api.games.ratings.show', $game))
+            ->assertNotFound()
+            ->assertJson([
+                'message' => 'Aucune note trouvée pour ce jeu.',
+            ]);
+    }
+
+    public function test_user_can_update_game_rating(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $game = Game::factory()->create();
+
+        GameRating::factory()->for($game, 'game')->for($user, 'user')->create(['rating' => 4]);
+
+        $response = $this->putJson(route('api.games.ratings.update', $game), ['rating' => 10]);
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'rating' => 10,
+            ]);
+
+        $this->assertDatabaseHas('game_ratings', [
+            'game_id' => $game->id,
+            'user_id' => $user->id,
+            'rating' => 10,
+        ]);
+    }
+
+    public function test_update_returns_not_found_when_rating_is_missing(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $game = Game::factory()->create();
+
+        $this->putJson(route('api.games.ratings.update', $game), ['rating' => 6])
+            ->assertNotFound()
+            ->assertJson([
+                'message' => 'Aucune note trouvée pour ce jeu.',
+            ]);
+    }
+
+    public function test_user_can_delete_game_rating(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $game = Game::factory()->create();
+
+        GameRating::factory()->for($game, 'game')->for($user, 'user')->create(['rating' => 3]);
+
+        $this->deleteJson(route('api.games.ratings.destroy', $game))
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('game_ratings', [
+            'game_id' => $game->id,
+            'user_id' => $user->id,
+        ]);
+    }
+
+    public function test_delete_returns_not_found_when_rating_is_missing(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $game = Game::factory()->create();
+
+        $this->deleteJson(route('api.games.ratings.destroy', $game))
+            ->assertNotFound()
+            ->assertJson([
+                'message' => 'Aucune note trouvée pour ce jeu.',
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add an API controller that exposes CRUD endpoints for authenticated users to manage their game ratings
- register RESTful routes under `/api/games/{game}/rating`
- cover the new API with feature tests for authentication, creation, update, display, and deletion scenarios

## Testing
- ⚠️ `php artisan test --testsuite=Feature --filter=GameRatingTest` *(fails: missing Composer dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de5e1c0fac832c837e5ebf3d29790c