### PR TITLE
Update navigation links to Premium page

### DIFF
--- a/resources/js/components/AppFooter.vue
+++ b/resources/js/components/AppFooter.vue
@@ -17,8 +17,8 @@ const footerLinks: FooterLink[] = [
         href: '/games',
     },
     {
-        title: 'Information',
-        href: '/information',
+        title: 'Premium',
+        href: '/premium',
     },
     {
         title: 'Présentation',

--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -49,8 +49,8 @@ const mainNavItems: NavItem[] = [
         href: '/games',
     },
     {
-        title: 'Information',
-        href: '/information',
+        title: 'Premium',
+        href: '/premium',
     },
     {
         title: 'Présentation',


### PR DESCRIPTION
## Summary
- update the main header navigation to link to the Premium page instead of Information
- update the footer navigation list to point to the Premium page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deeae680fc832c9bf04591984a431d