### PR TITLE
Handle Inertia redirects for subscription checkout

### DIFF
--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -1,9 +1,9 @@
 <?php
 
-// app/Http/Controllers/SubscriptionController.php
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 
 class SubscriptionController extends Controller
 {
@@ -24,13 +24,19 @@ class SubscriptionController extends Controller
         $price = $request->query('price') ?? env('STRIPE_PRICE_DEFAULT');
         abort_unless($price, 400, 'Missing price');
 
-        return $request->user()
+        $redirectResponse = $request->user()
             ->newSubscription('default', $price)
             ->allowPromotionCodes()
             ->checkout([
                 'success_url' => route('billing.success').'?session_id={CHECKOUT_SESSION_ID}',
                 'cancel_url'  => route('billing.cancel'),
             ]);
+
+        if ($request->inertia()) {
+            return Inertia::location($redirectResponse->getTargetUrl());
+        }
+
+        return $redirectResponse;
     }
 
     // Page succès


### PR DESCRIPTION
## Summary
- capture the Stripe checkout redirect response when starting a subscription
- return an Inertia location response when the request contains the Inertia header to trigger a full navigation
- fall back to the default redirect for non-Inertia requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb6010a10832cbd33f18c0a555b0e