### PR TITLE
Fix Inertia checkout redirect handling

### DIFF
--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -1,9 +1,9 @@
 <?php
 
-// app/Http/Controllers/SubscriptionController.php
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 
 class SubscriptionController extends Controller
 {
@@ -24,13 +24,21 @@ class SubscriptionController extends Controller
         $price = $request->query('price') ?? env('STRIPE_PRICE_DEFAULT');
         abort_unless($price, 400, 'Missing price');
 
-        return $request->user()
+        $checkout = $request->user()
             ->newSubscription('default', $price)
             ->allowPromotionCodes()
             ->checkout([
                 'success_url' => route('billing.success').'?session_id={CHECKOUT_SESSION_ID}',
                 'cancel_url'  => route('billing.cancel'),
             ]);
+
+        $redirectResponse = $checkout->redirect();
+
+        if ($request->inertia()) {
+            return Inertia::location($redirectResponse->getTargetUrl());
+        }
+
+        return $redirectResponse;
     }
 
     // Page succès


### PR DESCRIPTION
## Summary
- generate the Stripe checkout redirect response from the Checkout object
- return an Inertia location using the redirect target URL for Inertia requests
- keep the original redirect response for non-Inertia requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb6010a10832cbd33f18c0a555b0e