### PR TITLE
Update sidebar footer links handling

### DIFF
--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -5,7 +5,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid, Megaphone, MessageSquare, ShieldCheck } from 'lucide-vue-next';
+import { LayoutGrid, Megaphone, MessageSquare, ShieldCheck } from 'lucide-vue-next';
 import { computed } from 'vue';
 import AppLogo from './AppLogo.vue';
 
@@ -41,18 +41,7 @@ const mainNavItems = computed<NavItem[]>(() => {
     return items;
 });
 
-const footerNavItems: NavItem[] = [
-    {
-        title: 'Github Repo',
-        href: 'https://github.com/laravel/vue-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits',
-        icon: BookOpen,
-    },
-];
+const footerNavItems: NavItem[] = [];
 </script>
 
 <template>

--- a/resources/js/components/NavFooter.vue
+++ b/resources/js/components/NavFooter.vue
@@ -1,20 +1,23 @@
 <script setup lang="ts">
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
+import { computed } from 'vue';
 
 interface Props {
     items: NavItem[];
     class?: string;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+const hasItems = computed(() => props.items?.length ?? 0);
 </script>
 
 <template>
-    <SidebarGroup :class="`group-data-[collapsible=icon]:p-0 ${$props.class || ''}`">
+    <SidebarGroup v-if="hasItems" :class="`group-data-[collapsible=icon]:p-0 ${props.class || ''}`">
         <SidebarGroupContent>
             <SidebarMenu>
-                <SidebarMenuItem v-for="item in items" :key="item.title">
+                <SidebarMenuItem v-for="item in props.items" :key="item.title">
                     <SidebarMenuButton class="text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100" as-child>
                         <a :href="item.href" target="_blank" rel="noopener noreferrer">
                             <component :is="item.icon" />


### PR DESCRIPTION
## Summary
- remove outdated external footer links from the sidebar footer
- ensure the NavFooter component hides itself when there are no links to display

## Testing
- npx eslint resources/js/components/AppSidebar.vue resources/js/components/NavFooter.vue

------
https://chatgpt.com/codex/tasks/task_e_68dfc78ade1c832ca6a8c187657d3b42